### PR TITLE
Refactor indicators page; protect credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ chromedriver
 geckodriver
 errorShots
 *.jar
+config.json
 
 #allvritualenv
 venv/

--- a/test/js/README.md
+++ b/test/js/README.md
@@ -5,11 +5,17 @@ front-end code. TolaActivity using. The tools of choice are:
 
 * Selenium WebDriver for browser automation
 * Selenium Server for remote browsers (think Saucelabs, BrowserStack,
-* WebdriverIO, a test automation framework for NodeJS
-  and so forth)
+* WebdriverIO, a test automation framework for NodeJS with support
+  for synchronous or asynchronous JavaScript
 * MochaJS test framework with assorted plugins, particularly the Chai
   JS assertion library
 * Chrome and/or Firefox browsers
+* Selenium Server for supporting remote testing
+
+If you're reading this, you've already probably cloned the repo. If you
+haven't, do that, then come back here. Commands listed in this document
+assume you're working from the testing directory, `test/js` in the
+TolaActivity repo unless noted otherwise.
 
 ## Install Things
 First, download and install all the bits you'll need. These include
@@ -23,71 +29,71 @@ be current.
 [Firefox](https://www.mozilla.org/download) browsers.
 1. Download and install Chrome's Selenium browser driver,
 [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver).
-Place it anywhere in your system $PATH. You can also keep it in
-the top-level of your local repo because it is gitignored.
+Place it anywhere in your system $PATH. You may also keep it in
+the testing directory (`test/js`) of your local repo because it is 
+gitignored.
 1. Download and install Firefox's Selenium browser driver,
 [geckodriver](https://github.com/mozilla/geckodriver/releases).
 Place it anywhere in your system $PATH. You can also keep it in
-the top-level of your local repo because it is gitignored.
+the testing directory (`test/js`) of your local repo because it is 
+gitignored.
 1. Install [NodeJS](https://nodjs.org) so you can use the
-[Node Package Manager](https://www.npmjos.com), or _npm_ to install
+[Node Package Manager](https://www.npmjos.com), _npm_, to install
 other JavaScript packages.
-1. Finally, use `npm` to install the JavaScript language bindings
-for Selenium, the Mocha test framework, the Chai plugin for
-Mocha, and WebDriverIO:
+1. Download [Selenium Server](https://goo.gl/hvDPsK) and place it
+the testing directory (`test/js`).
+1. Finally, use `npm` to install all of the JavaScript language 
+bindings for Selenium, the Mocha test framework, the Chai plugin for
+Mocha, and WebDriverIO, and all of the other assorted dependencies
+bits:
 
 ```
-$ npm install selenium-webdriver mocha chai webdriverio
+$ npm install 
 [...]
 ```
 
 The resulting tech stack ![looks like this](./testing_stack.png)
 
 ## Validate the Installation
-1. Edit the config.json file in the top-level of the TolaActivity repo.
-Change the `username`, `password`, `baseurl`, and `browser` values to
-suit your taste, taste. In particular,
-    - `username` and `password` correspond to your MercyCorps SSO login
-    - `baseurl` points to the home page of the TolaActivity instance
-    you are testing
-    - `browser_name` sets the BUT (_b_rowser _u_nder _t_est), and should
-    be either `chrome` or `firefox`.
-1. From the top of the TolaActivity repo, setup the JS environment for
-the test suite:
+1. Make a copy the config-example.json file in the testing directory
+(`test/js`) of the TolaActivity repo:
 
 ```
 $ cd test/js
-$ npm install
-[...]
+$ cp config-example.json config.json
 ```
-1. Execute the test suite. **Note the bare `--`**. They tell `npm`
-to ignore the following arguments and pass them through to Mocha,
-the underlying test framework.
+
+Edit `config.json` and change the `username`, `password`, `baseurl`,
+and `browser` values to suit your taste, taste. In particular,
+* `username` and `password` correspond to your MercyCorps SSO login
+* `baseurl` points to the home page of the TolaActivity instance
+  you are testing
+* `browser_name` sets the BUT (browser under test), and should
+  be either `chrome` or `firefox`.
+1. Execute the test suite:
 
 ```
-$ npm test -- --no-timeouts
+$ cd test/js
+$ ./node_modules/.bin/wdio
 
-> @ test /home/kwall/Work/TolaActivity/test/js
-> mocha "--no-timeouts"
-
-  TolaActivity Dashboard
-    ✓ should require login authentication (2886ms)
-    ✓ should have home page link (940ms)
-    ✓ should have page header
-    ✓ should have a TolaActivity link (854ms)
-    ✓ should have a Country Dashboard dropdown (218ms)
+------------------------------------------------------------------
+[chrome #0-0] Session ID: db980c3deae94de17354e7000ee25288
+[chrome #0-0] Spec: /Users/kwall/repos/TolaActivity/test/js/test/specs/dashboard.js
+[chrome #0-0] Running: chrome
+[chrome #0-0]
+[chrome #0-0] TolaActivity Dashboard
+[chrome #0-0]   ✓ should require unauthenticated users to login
+[chrome #0-0]   ✓ should have a page header
+[chrome #0-0]   ✓ should have a TolaActivity link
 
     [...output deleted...]
 
-    - should default Number of events to 1
-    - should limit Number of events between 1 and 12
-    - should not permit edting saved targets except for LoP
-    - should disable the Target frequency menu after changes saved
-    - should enable only Remove all targets after targets saved
+==================================================================
+Number of specs: 6
 
 
-  28 passing (27s)
-  94 pending
+35 passing (42.80s)
+164 skipped
 ```
 1. Rejoice!
 
@@ -113,13 +119,9 @@ much, much simpler.
   people who come after us will thank us for using this small bit of
   semantic markup.
 
-* Similarly, it would be helpful for each page to have its own unique title.
-  Again, this makes programmatic access to page elements much less complicated
-  and reduces verifying that we've loaded the right page to a single short,
-  fast expression. This is less impactful than using _id_ or _name_ attributes
-  consistently, so if you can only do one of these, use _id_ or _name_ attributes
-  consistently.
-
-* Is there a naming convention at work in the structural and semantic
-  markup? I'm curious there is a pattern to the naming that test code
-  can exploit.
+* Similarly, it is helpful for each page to have its own unique
+  title. Again, this makes programmatic access to page elements much
+  less complicated and reduces verifying that we've loaded the right
+  page to a single short, fast expression. This is less impactful
+  than using _id_ or _name_ attributes consistently, so if you can
+  only do one of these, use _id_ or _name_ attributes consistently.

--- a/test/js/README.md
+++ b/test/js/README.md
@@ -41,7 +41,7 @@ $ npm install selenium-webdriver mocha chai webdriverio
 [...]
 ```
 
-The resulting tech stack [looks like this](testing.png)
+The resulting tech stack ![looks like this](./testing_stack.png)
 
 ## Validate the Installation
 1. Edit the config.json file in the top-level of the TolaActivity repo.

--- a/test/js/package-lock.json
+++ b/test/js/package-lock.json
@@ -924,7 +924,7 @@
 			"dev": true,
 			"requires": {
 				"caniuse-lite": "1.0.30000792",
-				"electron-to-chromium": "1.3.31"
+				"electron-to-chromium": "1.3.32"
 			}
 		},
 		"buffer-crc32": {
@@ -1243,9 +1243,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.31",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
-			"integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA==",
+			"version": "1.3.32",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.32.tgz",
+			"integrity": "sha1-EdBoTAhA4APEvoko+KxfNdvCtOY=",
 			"dev": true
 		},
 		"end-of-stream": {

--- a/test/js/package.json
+++ b/test/js/package.json
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"test": "mocha --require babel-register"
+		"test": "mocha --require babel-register --es_staging --harmony"
 	},
 	"devDependencies": {
 		"babel-cli": "^6.26.0",

--- a/test/js/test/lib/testutil.js
+++ b/test/js/test/lib/testutil.js
@@ -1,0 +1,10 @@
+// testutil.js -- Dumping ground for utility methods and objects
+// used in testing that don't fit anywhere else
+
+function readConfig(configFile = 'config.json') {
+  let fs = require('fs');
+  let data = fs.readFileSync(configFile);
+  return JSON.parse(data);
+}
+
+exports.readConfig = readConfig;

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -1,0 +1,74 @@
+// indicators.page.js -- page object for testing the top-level Program
+// Indicators page 
+var util = require('../lib/testutil.js');
+
+var parms = util.readConfig();
+parms.baseurl += '/indicators/home/0/0/0';
+
+function clickProgramsDropdown() {
+  browser.$('#dropdownProgram').click();
+}
+
+function getProgramsList() {
+  let items = browser.$('div.btn-group').$('ul.dropdown-menu').$$('li>a');
+  let programs = new Array();
+  for (let item of items) {
+    programs.push(item.getText());
+  }
+  return programs;
+}
+
+function getProgramsTable() {
+  let rows = browser.$('div#toplevel_div').$$('div.panel-heading');
+  let programs = new Array();
+  for(let row of rows) {
+    programs.push(row.$('h4').getText());
+  }
+  return programs;
+}
+
+function open(url = parms.baseurl) {
+  browser.url(url);
+}
+
+// FIXME: This should be a property
+function pageName() {
+  // On this page, the "title" is actually the <h2> caption
+  return browser.getText('h2=Program Indicators');
+}
+
+function selectProgram(program) {
+  browser.$('#dropdownProgram').click();
+  let items = browser.$('div.btn-group').$('ul.dropdown-menu').$$('li>a');
+  for (let item of items) {
+    if (program == item.getText()) {
+      item.click();
+      break;
+    }
+  }
+}
+
+exports.clickProgramsDropdown = clickProgramsDropdown;
+exports.getProgramsList = getProgramsList;
+exports.getProgramsTable = getProgramsTable;
+exports.open = open;
+exports.pageName = pageName;
+exports.selectProgram = selectProgram;
+
+/*
+exports.clickProgramsDropdown = clickProgramsDropdown;
+exports.clickIndicatorDataButton = clickIndicatorDataButton;
+exports.clickIndicatorDeleteButton = clickIndicatorDeleteButton;
+exports.clickIndicatorEditButton = clickIndicatorEditButton;
+exports.clickNewIndicatorButton = clickNewIndicatorButton;
+exports.clickPerformanceTab = clickPerformanceTab;
+exports.clickProgramIndicatorsButton = selectProgram;
+exports.clickSaveChangesButton = clickSaveChangeButton;
+exports.clickSaveNewIndicatorButton = clickSaveNewIndicatorButton;
+exports.clickTargetsTab = clickTargetsTab;
+exports.selectTargetFrequency = selectTargetFrequency;
+exports.setBaselineValue = setBaselineValue;
+exports.setIndicatorName = setIndicatorName;
+exports.setLoPTarget = setLoPTarget;
+exports.setUnitOfMeasure = setUnitOfMeasure;
+*/

--- a/test/js/test/pages/login.page.js
+++ b/test/js/test/pages/login.page.js
@@ -1,0 +1,25 @@
+// login.page.js -- Page model and methods for login page
+// for use in testing
+function open(url) {
+  browser.url(url);
+}
+
+function setUserName(username) {
+  let loginBox = $('#login');
+  loginBox.setValue(username);
+}
+
+function setPassword(password) {
+  let passwordBox = $('#password');
+  passwordBox.setValue(password);
+}
+
+function clickLoginButton() {
+  let loginButton = $('.inputsub');
+  loginButton.click();
+}
+
+exports.open = open;
+exports.setUserName = setUserName;
+exports.setPassword = setPassword;
+exports.clickLoginButton = clickLoginButton;

--- a/test/js/test/specs/dashboard.js
+++ b/test/js/test/specs/dashboard.js
@@ -1,39 +1,21 @@
-var assert = require('assert');
-var fs = require('fs');
-
-function readConfig() {
-  let data = fs.readFileSync('config.json');
-    return JSON.parse(data);
-};
-var parms = readConfig();
+var assert = require('chai').assert;
+var LoginPage = require('../pages/login.page.js');
+var util = require('../lib/testutil.js');
     
 describe('TolaActivity Dashboard', function() {
-  it('should require user to authenticate', function() {
-    browser.url(parms.baseurl);
-    var title = browser.getTitle();
-    assert.equal(title, 'Mercy Corps Sign-On');
-  });
-
-  it('should have a login field', function() {
-    var login = $('#login');
-    login.setValue(parms.username);
-  });
-
-  it('should have a password field', function() {
-    var password = $('#password');
-    password.setValue(parms.password);
-  });
-
-  it('should have a Log In button', function() {
-    var button = $('.inputsub');
-    button.click();
+  it('should require unauthenticated users to login', function() {
+    let parms = util.readConfig();
+    LoginPage.open(parms.baseurl);
+    LoginPage.setUserName(parms.username);
+    LoginPage.setPassword(parms.password);
+    LoginPage.clickLoginButton();
   });
 
   // after all of that, we should wind up at the dashboard
   it('should have a page header', function() {
     browser.waitForText('h4', 5000)
     var h4 = $('h4');
-    assert(h4.getText() ==  'Tola-Activity Dashboard');
+    assert(h4.getText() == 'Tola-Activity Dashboard');
   });
 
   it('should have a TolaActivity link', function() {

--- a/test/js/test/specs/indicators.js
+++ b/test/js/test/specs/indicators.js
@@ -1,122 +1,79 @@
 var assert = require('chai').assert;
-var fs = require('fs');
-
-function readConfig() {
-  let data = fs.readFileSync('config.json');
-  return JSON.parse(data);
-};
-
+var LoginPage = require('../pages/login.page.js');
+var IndPage = require('../pages/indicators.page.js');
+var util = require('../lib/testutil.js');
+    
 describe('TolaActivity Program Indicators page', function() {
   // Disable timeouts
   this.timeout(0);
-  var parms = readConfig();
-
-  // TODO: add test
-  it('should require user to authenticate', function() {
-    browser.url(parms.baseurl);
-    var title = browser.getTitle();
-    assert.equal(title, 'Mercy Corps Sign-On');
-  });
-
-  it('should have a login field', function() {
-    var login = $('#login');
-    login.setValue(parms.username);
-  });
-
-  it('should have a password field', function() {
-    var password = $('#password');
-    password.setValue(parms.password);
-  });
-
-  it('should have a Log In button', function() {
-    button = $('.inputsub');
-    button.click();
-  });
 
   it('should exist', function() {
-    browser.url(parms.baseurl + '/indicators/home/0/0/0/');
-    browser.waitForText('h2');
-    var h2 = $('h2');
-    assert.equal(h2.getText(), 'Program Indicators');
+    let parms = util.readConfig();
+    LoginPage.open(parms.baseurl);
+    LoginPage.setUserName(parms.username);
+    LoginPage.setPassword(parms.password);
+    LoginPage.clickLoginButton();
+    IndPage.open();
+    // FIXME: pageName should be a property
+    assert.equal('Program Indicators', IndPage.pageName());
   });
 
   describe('Programs dropdown', function() {
     it('should be present on page', function() {
-      var button = $('#dropdownProgram');
-      assert(button.getText() == 'Programs');
+      IndPage.clickProgramsDropdown();
     });
 
-    it('should have same count on button as in Programs table', function() {
-      var buttons = $('div.panel').$$('div.btn-group');
-      var programs = buttons[0];
-      // have to click to make the menu visible
-      programs.click();
-      var menu = programs.$('ul.dropdown-menu');
-      var progList = menu.$$('li');
-      programs.click();
-
-      var table = $('div#toplevel_div')
-      var tableRows = table.$$('div.panel-heading');
-      assert(progList.length === tableRows.length);
+    it('should have same number of items as the Programs table', function() {
+      IndPage.clickProgramsDropdown();
+      let progList = IndPage.getProgramsList();
+      let progTable = IndPage.getProgramsTable();
+      assert.equal(progList.length, progTable.length, 'row count mismatch');
+      IndPage.clickProgramsDropdown();
     });
 
     it('should have same items as Programs table', function() {
-      var buttons = $('div.panel').$$('div.btn-group');
-      var dropdown = buttons[0];
-      // have to click to make the menu visible
-      dropdown.click();
-      var dropdownList = dropdown.$('ul.dropdown-menu').$$('li');
-      var progList = Array();
-      for (let item of dropdownList) {
-        var listitem = item.$('a').getText();
-        progList.push(listitem.split('-')[1].trim());
+      let progList = IndPage.getProgramsList();
+      let listItems = new Array();
+      for (let prog of progList) {
+        let name = prog.split('-')[1].trim();
+        listItems.push(name);
       }
-      dropdown.click();
 
-      var table = $('div#toplevel_div')
-      var tableRows = table.$$('div.panel-heading');
-      for (let i = 0; i < tableRows.length; i++) {
-        let s = tableRows[i].$('h4').getText().split("\n")[0].trim();
-        assert.equal(s, progList[i]);
+      let progTable = IndPage.getProgramsTable();
+      for (let i = 0; i < progTable.length; i++) {
+        let rowText = progTable[i].split('\n')[0].trim();
+        assert.equal(rowText, listItems[i]);
       };
     });
 
     it('should filter programs table by selected program name', function() {
-      var buttons = $('div.panel').$$('div.btn-group');
-      var dropdown = buttons[0];
-      // have to click to make the menu visible
-      dropdown.click();
-      var dropdownList = dropdown.$('ul.dropdown-menu').$$('li');
-      var item = dropdownList[0];
-      var listitem = item.$('a');
-      var progName = listitem.getText().split('-')[1].trim();
-      item.click();
+      //IndPage.clickProgramsDropdown();
+      let progList = IndPage.getProgramsList();
+      let listItem = progList[0];
+      IndPage.selectProgram(listItem);
 
       // should have a single row in the table
-      browser.waitForText('h4');
-      var table = $('div#toplevel_div')
-      var tableRows = table.$$('div.panel-heading');
-      assert.equal(1, tableRows.length);
-
+      let progTable = IndPage.getProgramsTable();
       // row should be the one selected from the dropdown
-      s = tableRows[0].$('h4').getText().split("\n")[0].trim();
-      assert.equal(s, progName);
+      let rowText = progTable[0].split('\n')[0].trim();
+      let listText = listItem.split('-')[1].trim();
+      assert.equal(rowText, listText, 'program name mismtach');
     });
   }); // end programs dropdown tests
 
   describe('Indicators dropdown', function() {
     it('should be present on page', function() {
-      var button = $('#dropdownIndicator');
+      let button = $('#dropdownIndicator');
       assert(button.getText() == 'Indicators');
     });
 
     it('should have at least one entry', function() {
-      var buttons = $('div.panel').$$('div.btn-group');
-      var indicators = buttons[1];
+      let buttons = $('div.panel').$$('div.btn-group');
+      let indicators = buttons[1];
 
       // have to click to make the menu visible
       indicators.click();
-      var dropdownList = indicators.$('ul.dropdown-menu').$$('li');
+      let dropdownList = indicators.$('ul.dropdown-menu').$$('li');
       indicators.click();
       assert(dropdownList.length > 0);
     });
@@ -126,19 +83,19 @@ describe('TolaActivity Program Indicators page', function() {
 
   describe('Indicator Type dropdown', function() {
     it('should be present on page', function() {
-      var button = $('#dropdownIndicatorType');
+      let button = $('#dropdownIndicatorType');
       assert(button.getText() == 'Indicator Type');
       button.click();
     });
 
     it('should have at least one entry', function() {
-      var buttons = $('div.panel').$$('div.btn-group');
-      var indicatorType = buttons[2];
+      let buttons = $('div.panel').$$('div.btn-group');
+      let indicatorType = buttons[2];
 
       // have to click to make the menu visible
       // TODO: Validate the indicator type list as static
       indicatorType.click();
-      var dropdownList = indicatorType.$('ul.dropdown-menu').$$('li');
+      let dropdownList = indicatorType.$('ul.dropdown-menu').$$('li');
       indicatorType.click();
       assert(dropdownList.length > 0);
     });
@@ -148,13 +105,13 @@ describe('TolaActivity Program Indicators page', function() {
   }); // end indicator type dropdown tests
 
   it('should toggle PIs table by clicking PI Indicators button', function() {
-    progIndTable = $('#toplevel_div');
-    buttons = progIndTable.$$('div.panel-body');
+    let progIndTable = $('#toplevel_div');
+    let buttons = progIndTable.$$('div.panel-body');
     for (let button of buttons) {
       // starts out collapsed
-      var link = button.$('a');
-      var target = link.getAttribute('data-target');
-      var state = browser.isVisible('div' + target);
+      let link = button.$('a');
+      let target = link.getAttribute('data-target');
+      let state = browser.isVisible('div' + target);
       assert(!state);
 
       // open it and verify
@@ -172,26 +129,26 @@ describe('TolaActivity Program Indicators page', function() {
   it('should have matching indicator counts on data button and in table', function() {
     // FIXME: The hard pauses are a poor WAR for the button we want to click sometimes
     // being occluded by another element.
-    progIndTable = $('#toplevel_div');
-    buttons = progIndTable.$$('div.panel-body');
+    let progIndTable = $('#toplevel_div');
+    let buttons = progIndTable.$$('div.panel-body');
     for (let button of buttons) {
-      var buttonCnt = parseInt(button.$('a').getText());
-      var link = button.$('a');
+      let buttonCnt = parseInt(button.$('a').getText());
+      let link = button.$('a');
       // expand the table
       link.click();
-      browser.pause(1500);
+      browser.pause(500);
 
       // indicator count from table
-      var targetDiv = link.getAttribute('data-target');
-      var table = $('div' + targetDiv).$('table');
-      var tableRows = table.$$('tbody>tr>td>a');
+      let targetDiv = link.getAttribute('data-target');
+      let table = $('div' + targetDiv).$('table');
+      let tableRows = table.$$('tbody>tr>td>a');
       // divide by 2 because each <tr> has a blank <tr> spacer row
       // beneath it
       assert.equal(buttonCnt, (tableRows.length / 2), 'evidence count mismatch');
 
       // collapse the table
       link.click();
-      browser.pause(1500);
+      browser.pause(500);
     }
   }, 3); // retry this flaky test 2 more times before failing
 
@@ -203,7 +160,7 @@ describe('TolaActivity Program Indicators page', function() {
       let target = link.getAttribute('data-target');
       let targetDiv = $('div' + target);
       link.click();
-      browser.pause(1500);
+      browser.pause(500);
 
       let table = targetDiv.$('table');
       let tableRows = table.$$('tbody>tr>td>a.indicator-link');
@@ -223,6 +180,7 @@ describe('TolaActivity Program Indicators page', function() {
     });
 
     it('should be able to create PI by clicking the New Indicator button', function() {
+      browser.pause(500);
       let newButtons = $('div#toplevel_div').$('div.panel-heading').$$('h4>span>a');
       let newButton = newButtons[0];
       newButton.click();
@@ -232,16 +190,25 @@ describe('TolaActivity Program Indicators page', function() {
       let form = $('form');
       let saveNew = form.$('input.btn.btn-success');
       saveNew.click();
-      assert.equal('Success, Basic Indicator Created!', $('div.alert.alert-success').getText());
+      assert.equal('Success, Basic Indicator Created!',
+                   $('div.alert.alert-success').getText());
+
+      // Find the Performance tab
+      let tabs = $$('li.tab-pane>a');
+      let perfTab = tabs[1];
+      let indName = $('input#id_name');
+      assert.equal('Performance', perfTab.getText());
+      perfTab.click();
+      // A name unlikely to clash with real data
+      indName.setValue('===> Delete Me! <===');
 
       // Find the Targets tab
-      let tabs = $$('li.tab-pane>a');
       let targetsTab = tabs[2];
       assert.equal('Targets', targetsTab.getText());
       targetsTab.click();
 
       // Add some values
-      let bucket = $('input#id_units_of_measure');
+      let bucket = $('input#id_unit_of_measure');
       bucket.setValue('Buckets');
       let lopTarget = $('input#id_lop_target');
       lopTarget.setValue('10');
@@ -251,20 +218,19 @@ describe('TolaActivity Program Indicators page', function() {
       targetFreq.selectByValue(1);
 
       // Save
-      let saveUpdate = $('input.btn.btn-primary');
-      assert.equal('Save changes', saveUpdate.getText());
-      saveUpdate.click();
-    }, 3);
+      let saveChanges = $('input.btn.btn-primary');
+      assert.equal('Save changes', saveChanges.getValue());
+      saveChanges.click();
+    });
 
     it('should increase PI count after adding new indicator');
     it('should be able to delete PI by clicking its Delete button');
+    it('should decrease PI count after deleting indicator');
     it('should be able to edit PI by clicking its Edit button');
-    it('should open the Create an Indicator form when New Indicator button is clicked');
     it('should open the Grid/Print Report page when button is clicked');
     it('should highlight invalid data');
     it('should return to previous screen if Cancel button clicked');
     it('should clear form when Clear button clicked');
-    it('should decrease PI count after deleting indicator');
 
     describe('Create an Indicator form', function() {
       it('should show context-sensitve help by clicking Form Help/Guidance button');

--- a/test/js/test/specs/invalid_password.js
+++ b/test/js/test/specs/invalid_password.js
@@ -1,43 +1,20 @@
-var assert = require('assert');
-var fs = require('fs');
-
-// basic auth and session information
-function readConfig() {
-  let data = fs.readFileSync('config.json');
-  return JSON.parse(data);
-}
-var parms = readConfig();
-
-describe('TolaActivity invalid password login', function() {
-  // inject bogus password
-  parms.password = 'thisbetterfail';
-
-  it('should require user to authenticate', function() {
-    browser.url(parms.baseurl);
-    var title = browser.getTitle();
-    assert.equal(title, 'Mercy Corps Sign-On');
-  });
-
-  it('should have a login field', function() {
-    var login = $('#login');
-    login.setValue(parms.username);
-  });
-
-  it('should have a password field', function() {
-    var password = $('#password');
-    password.setValue(parms.password);
-  });
-
-  it('should have a Log In button', function() {
-    var button = $('.inputsub');
-    button.click();
-  });
+var assert = require('chai').assert;
+var LoginPage = require('../pages/login.page.js');
+var util = require('../lib/testutil.js');
+    
+describe('TolaActivity login screen', function() {
+  this.timeout(0);
 
   it('should deny access if password is invalid', function() {
-    browser.waitUntil(function() {
-      return browser.getText('#error').startsWith('Login failed:');
-      },
-      5000,
-      'expected login failure message');
+    let parms = util.readConfig();
+    // inject bogus password
+    parms.password = 'ThisBetterFail';
+
+    LoginPage.open(parms.baseurl);
+    LoginPage.setUserName(parms.username);
+    LoginPage.setPassword(parms.password);
+    LoginPage.clickLoginButton();
+    
+    assert(browser.getText('#error').startsWith('Login failed:'));
   });
 });

--- a/test/js/test/specs/invalid_username.js
+++ b/test/js/test/specs/invalid_username.js
@@ -1,41 +1,20 @@
-var assert = require('assert');
-var fs = require('fs');
+var assert = require('chai').assert;
+var LoginPage = require('../pages/login.page.js');
+var util = require('../lib/testutil.js');
 
-// basic auth and session information
-function readConfig() {
-  let data = fs.readFileSync('config.json');
-  return JSON.parse(data);
-}
-var parms = readConfig();
+describe('TolaActivity login screen', function() {
+  this.timeout(0);
+    
+  it('should deny access if username is invalid', function() {
+    let parms = util.readConfig();
+    // inject bogus username
+    parms.username = 'HorseWithNoName';
 
-describe('TolaActivity invalid username login', function() {
-  // inject bogus username
-  parms.username = 'HorseWithNoName';
-
-  it('should require user to authenticate', function() {
-    browser.url(parms.baseurl);
-    var title = browser.getTitle();
-    assert.equal(title, 'Mercy Corps Sign-On');
-  });
-
-  it('should have a login field', function() {
-    var login = $('#login');
-    login.setValue(parms.username);
-  });
-
-  it('should have a password field', function() {
-    var password = $('#password');
-    password.setValue(parms.password);
-  });
-
-  it('should have a Log In button', function() {
-    var button = $('.inputsub');
-    button.click();
-  });
-
-  it('should deny access if password is invalid', function() {
-    browser.waitUntil(function() {
-      return browser.getText('#error').startsWith('Login failed:');
-      }, 5000, 'expected login failure message');
+    LoginPage.open(parms.baseurl);
+    LoginPage.setUserName(parms.username);
+    LoginPage.setPassword(parms.password);
+    LoginPage.clickLoginButton();
+    
+    assert(browser.getText('#error').startsWith('Login failed:'));
   });
 });

--- a/test/js/test/specs/login.js
+++ b/test/js/test/specs/login.js
@@ -1,34 +1,18 @@
-var assert = require('assert');
-var fs = require('fs');
-
-function readConfig() {
-  let data = fs.readFileSync('config.json');
-  return JSON.parse(data);
-}
-var parms = readConfig();
+var assert = require('chai').assert;
+var LoginPage = require('../pages/login.page.js');
+var util = require('../lib/testutil.js');
 
 describe('TolaActivity Login screen', function() {
+  this.timeout(0);
 
-  it('should require user to authenticate', function() {
-    browser.url(parms.baseurl);
-    var title = browser.getTitle();
-    assert.equal(title, 'Mercy Corps Sign-On');
+  it('should require unauthenticated user to authenticate', function() {
+    let parms = util.readConfig();
+    LoginPage.open(parms.baseurl);
+    assert.equal('Mercy Corps Sign-On', browser.getTitle());
+    LoginPage.setUserName(parms.username);
+    LoginPage.setPassword(parms.password);
+    LoginPage.clickLoginButton();
+    // FIXME: Get the WebDriver code out of the test
+    assert.equal('TolaActivity', browser.getTitle());
   });
-
-  it('should have a login field', function() {
-    var login = $('#login');
-    login.setValue(parms.username);
-  });
-
-  it('should have a password field', function() {
-    var password = $('#password');
-    password.setValue(parms.password);
-  });
-
-  it('should have a Log In button', function() {
-    button = $('.inputsub');
-    button.click();
-  });
-
 });
-

--- a/test/js/test/specs/target.js
+++ b/test/js/test/specs/target.js
@@ -1,16 +1,17 @@
-var assert = require('assert');
-var fs = require('fs');
-
-function readConfig() {
-  let data = fs.readFileSync('config.json');
-  return JSON.parse(data);
-};
-var parms = readConfig();
-
+var assert = require('chai').assert;
+var LoginPage = require('../pages/login.page.js');
+var util = require('../lib/testutil.js');
+    
 describe('Indicators Targets', function() {
+  it('should require unauthenticated users to login', function() {
+    let parms = util.readConfig();
+    LoginPage.open(parms.baseurl);
+    LoginPage.setUserName(parms.username);
+    LoginPage.setPassword(parms.password);
+    LoginPage.clickLoginButton();
+  });
   it('should open to Summary tab');
   it('should be able to select Midline and endline option');
-  it('should open Create new indicator dialog when New Indicator button is clicked');
   it('should save a record and open the Indicator edit page');
   it('should clear form when Reset button clicked');
   it('should save data when Save changes screen clicked');

--- a/test/js/wdio.conf.js
+++ b/test/js/wdio.conf.js
@@ -128,8 +128,8 @@ exports.config = {
     // See the full list at http://mochajs.org/
     mochaOpts: {
         ui: 'bdd',
-        compilers: ['js:babel-register'],
-        // require: ['./test/helpers/common.js']
+        compilers: ['js:babel-register']
+        //require: 'babel-register'
     },
     //
     // =====


### PR DESCRIPTION
Two set of changes in this PR, and then I'll stop submitting kitchen sink PRs. The most important change adds config.json to gitignore so I quit checking my credentials into a public repo. The second set of changes starts moving the indicators page to the page object pattern. Third change brings the README up-to-date with the state of the framework and corrects a broken link.