### PR TITLE
Add JSDoc tags and a Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ errorShots
 *.jar
 config.json
 test/js/node_modules/
+test/js/doc/
 
 #allvritualenv
 venv/

--- a/test/js/Makefile
+++ b/test/js/Makefile
@@ -1,0 +1,27 @@
+.default: help
+
+help:
+	@echo "clean: remove all logs and generated files"
+	@echo "update: refresh packages in top-level package.json file"
+	@echo "update-all: refresh all packages in node_modules"
+	@echo "doc: (re)generate test suite documentation"
+
+install:
+	npm install --verbose
+
+update:
+	npm update --dev --save
+
+update-all:
+	cd node_modules && npm update --dev --save && cd ..
+
+clean:
+	rm -fvr doc errorShots node_modules selenium-server.log 
+
+doc:
+	./node_modules/.bin/jsdoc --verbose \
+		--package package.json \
+		--recurse \
+		--destination doc \
+		--readme README.md \
+		test/lib test/pages -R README.md

--- a/test/js/README.md
+++ b/test/js/README.md
@@ -1,21 +1,21 @@
-# Using MochaJS and Selenium WebDriver to Test the TolaActivity UI
+# Using Selenium WebDriver to Test the TolaActivity UI
 
 This document describes how to set up your system to test TolaActivity
-front-end code. TolaActivity using. The tools of choice are:
+front-end code. The tools of choice are:
 
 * Selenium WebDriver for browser automation
 * Selenium Server for remote browsers (think Saucelabs, BrowserStack,
+  or TestBot)
 * WebdriverIO, a test automation framework for NodeJS with support
   for synchronous or asynchronous JavaScript
 * MochaJS test framework with assorted plugins, particularly the Chai
   JS assertion library
 * Chrome and/or Firefox browsers
-* Selenium Server for supporting remote testing
 
 If you're reading this, you've already probably cloned the repo. If you
 haven't, do that, then come back here. Commands listed in this document
 assume you're working from the testing directory, `test/js` in the
-TolaActivity repo unless noted otherwise.
+TolaActivity repo, unless noted otherwise.
 
 ## Install Things
 First, download and install all the bits you'll need. These include
@@ -25,23 +25,21 @@ the NPM-packaged Chrome or Firefox webdrivers because they might not
 be current.
 
 1. Install the latest versions of the
-[Chrome](ttps://www.google.com/chrome/browser/) and
+[Chrome](https://www.google.com/chrome/browser) and
 [Firefox](https://www.mozilla.org/download) browsers.
 1. Download and install Chrome's Selenium browser driver,
 [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver).
 Place it anywhere in your system $PATH. You may also keep it in
-the testing directory (`test/js`) of your local repo because it is 
-gitignored.
+the testing directory of your local repo because it is gitignored.
 1. Download and install Firefox's Selenium browser driver,
 [geckodriver](https://github.com/mozilla/geckodriver/releases).
 Place it anywhere in your system $PATH. You can also keep it in
-the testing directory (`test/js`) of your local repo because it is 
-gitignored.
-1. Install [NodeJS](https://nodjs.org) so you can use the
-[Node Package Manager](https://www.npmjos.com), _npm_, to install
-other JavaScript packages.
+the testing directory of your local repo because it is gitignored.
 1. Download [Selenium Server](https://goo.gl/hvDPsK) and place it
-the testing directory (`test/js`).
+the testing directory.
+1. Install [NodeJS](https://nodjs.org) so you can use the
+[Node Package Manager](https://www.npmjos.com), `npm`,  to install
+other JavaScript packages.
 1. Finally, use `npm` to install all of the JavaScript language 
 bindings for Selenium, the Mocha test framework, the Chai plugin for
 Mocha, and WebDriverIO, and all of the other assorted dependencies
@@ -52,11 +50,9 @@ $ npm install
 [...]
 ```
 
-The resulting tech stack: ![](./testing_stack.jpg)
-
 ## Validate the Installation
 1. Make a copy the config-example.json file in the testing directory
-(`test/js`) of the TolaActivity repo:
+   of the TolaActivity repo:
 
 ```
 $ cd test/js
@@ -64,12 +60,17 @@ $ cp config-example.json config.json
 ```
 
 Edit `config.json` and change the `username`, `password`, `baseurl`,
-and `browser` values to suit your taste, taste. In particular,
+and `browser` values to suit your taste, taste. In particular:
 * `username` and `password` correspond to your MercyCorps SSO login
 * `baseurl` points to the home page of the TolaActivity instance
   you are testing
-* `browser_name` sets the BUT (browser under test), and should
-  be either `chrome` or `firefox`.
+1. Start the Seleniuim server:
+
+```
+$ cd test/js
+$ java -jar -Dwebdriver.firefox.driver=./geckodriver selenium-server-standalone-3.8.1.jar &> selenium-server.log &
+```
+
 1. Execute the test suite:
 
 ```
@@ -95,7 +96,13 @@ Number of specs: 6
 35 passing (42.80s)
 164 skipped
 ```
-1. Rejoice!
+
+1. To run the tests in a single file, specify `--spec path/to/file`.
+   For example, to run only the dashboard tests, the command would be
+
+```
+$ ./node_modules/.bin/wdio --spec test/specs/dashboard.js
+```
 
 ## Helpful development practices
 

--- a/test/js/README.md
+++ b/test/js/README.md
@@ -59,11 +59,12 @@ $ cd test/js
 $ cp config-example.json config.json
 ```
 
-Edit `config.json` and change the `username`, `password`, `baseurl`,
-and `browser` values to suit your taste, taste. In particular:
+Edit `config.json` and change the `username`, `password`, and `baseurl`
+values to suit your needs. In particular:
 * `username` and `password` correspond to your MercyCorps SSO login
-* `baseurl` points to the home page of the TolaActivity instance
-  you are testing
+* `baseurl` points to the home page of the TolaActivity instance you
+  are testing
+
 1. Start the Seleniuim server:
 
 ```
@@ -97,12 +98,37 @@ Number of specs: 6
 164 skipped
 ```
 
+### Don't want to run everything?
 1. To run the tests in a single file, specify `--spec path/to/file`.
    For example, to run only the dashboard tests, the command would be
 
 ```
 $ ./node_modules/.bin/wdio --spec test/specs/dashboard.js
 ```
+
+### Looking for documentation?
+
+To produce documentation for the test suite, execute the command `make
+doc` at the top of the TolaActivity repo:
+
+```
+$ make doc
+./node_modules/.bin/jsdoc --verbose \
+  --package package.json \
+  --recurse \
+  --destination doc \
+  --readme README.md \
+  test/lib test/pages -R README.md
+Parsing /home/kwall/Work/TolaActivity/test/js/test/lib/testutil.js ...
+Parsing /home/kwall/Work/TolaActivity/test/js/test/pages/indicators.page.js ...
+Parsing /home/kwall/Work/TolaActivity/test/js/test/pages/login.page.js ...
+Generating output files...
+Finished running in 0.15 seconds.
+
+```
+
+The resulting output is best viewed in your browser. To do so, open 
+file:///path/to/your/repo/doc/index.html in your web browser.
 
 ## Helpful development practices
 
@@ -114,7 +140,7 @@ much, much simpler.
   the most is to **use either the _id_ or _name_ attribute on all UI
   elements which require, which _might_ require, or which you are
   even _thinking_ about requiring for user interaction.** These attributes
-  make it easier to write tests quickly because thee have to be unique
+  make it easier to write tests quickly because they have to be unique
   per-page, so tests can rely on being able to access the page elements
   they need. They also make element queries fast, because such lookups
   are Selenium's happy path.

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -20,6 +20,7 @@ function clickIndicatorsDropdown() {
 
 function clickIndicatorsLink() {
   browser.$('=Indicators').click();
+  browser.waitForText('h2');
 }
 
 function clickIndicatorTypeDropdown() {
@@ -61,7 +62,6 @@ function getIndicatorsList() {
 }
 
 function getAlertMsg() {
-  //let alertDiv = browser.$('div#alerts>div.alert.alert-danger.dynamic-alert.alert-dismissable');
   let alertDiv = browser.$('div#alerts');
   return alertDiv.$('p').getText();
 }
@@ -148,8 +148,12 @@ function setBaseline(value = false) {
     let baseline = $('input#id_baseline');
     baseline.setValue(value);
   } else {
-      browser.$('#id_baseline_na').click();
+      setBaselineNA();
   }
+}
+
+function setBaselineNA() {
+  browser.$('#id_baseline_na').click()
 }
 
 function setIndicatorName(name) {
@@ -230,6 +234,7 @@ exports.setIndicatorName = setIndicatorName;
 exports.setUnitOfMeasure = setUnitOfMeasure;
 exports.setLoPTarget = setLoPTarget;
 exports.setBaseline = setBaseline;
+exports.setBaselineNA = setBaselineNA;
 exports.setTargetFrequency = setTargetFrequency;
 
 /*

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -7,21 +7,21 @@ var parms = util.readConfig();
 parms.baseurl += '/indicators/home/0/0/0';
 
 /** Click the indicator data button for the specified indicator
- * @param {string} indicatorName - The name of the indicator
+ * @param {string} indicatorName The name of the indicator
  * @returns Nothing
  */
 function clickIndicatorDataButton(indicatorName) {
 }
 
 /** Click the delete button for the specified indicator
- * @param {string} indicatorName - The name of the indicator to delete
+ * @param {string} indicatorName The name of the indicator to delete
  * @returns Nothing
  */
 function clickIndicatorDeleteButton(indicatorName) {
 }
 
 /** Click the indicator data button for the specified indicator
- * @param {string} indicatorName - The name of the indicator to edit
+ * @param {string} indicatorName The name of the indicator to edit
  * @returns Nothing
  */
 function clickIndicatorEditButton(indicatorName) {
@@ -50,7 +50,7 @@ function clickIndicatorTypeDropdown() {
 
 // FIXME: Should this be a per-program method?
 /** Click the New Indicator button for the current program
- * @param {string} - The name of the indicator
+ * @param {string} The name of the indicator
  * @returns Nothing
  */
 function clickNewIndicatorButton() {
@@ -73,11 +73,11 @@ function clickResetButton() {
 }
 
 /** Create a new basic indicator with the specified required values
- * @param {string} name - The new name for the indicator (defaults to "Temporary")
- * @param {string} unit - The unit of measurement for this target
- * @param {integer} lopTarget - The LoP target for this indicator
- * @param {integer|boolean} - Non-zero integer OR false if a baseline is not applicable
- * @param {string} frequency - One of the 8 pre-defined periodic intervals
+ * @param {string} name The new name for the indicator (defaults to "Temporary")
+ * @param {string} unit The unit of measurement for this target
+ * @param {integer} lopTarget The LoP target for this indicator
+ * @param {integer|boolean} Non-zero integer OR false if a baseline is not applicable
+ * @param {string} frequency One of the 8 pre-defined periodic intervals
  * @returns Nothing
  */
 function createNewProgramIndicator(name, unit, lopTarget, baseline, frequency) {
@@ -101,7 +101,7 @@ function getAlertMsg() {
 }
 
 /** Get the current value of the target baseline from the indicators detail screen
- * @returns {integer} - The current value of the Baseline text field
+ * @returns {integer} The current value of the Baseline text field
  */
 function getBaseline() {
   let targetsTab = browser.$('=Targets');
@@ -111,7 +111,7 @@ function getBaseline() {
 }
 
 /** Get the current indicator name (from the Performance tab)
- * @returns {string} - The current value of the indicator name from the Performance
+ * @returns {string} The current value of the indicator name from the Performance
  * tab of the indicator detail screen
  */
 function getIndicatorName() {
@@ -122,7 +122,7 @@ function getIndicatorName() {
 }
 
 /** Get a list of the indicator types in the Indicator Type dropdown
- * Returns {Array<string>} - returns an array of the text strings making up the
+ * Returns {Array<string>} returns an array of the text strings making up the
  * indicator types dropdown menu
  */
 function getIndicatorTypeList() {
@@ -136,7 +136,7 @@ function getIndicatorTypeList() {
 }
 
 /** Get a list of the indicators in the Indicators dropdown
- * Returns {Array<string>} - returns an array of the text strings making up the
+ * Returns {Array<string>} returns an array of the text strings making up the
  * indicators dropdown menu
  */
 function getIndicatorsList() {
@@ -150,7 +150,7 @@ function getIndicatorsList() {
 }
 
 /** Get the current LoP target from the the target indicators detail page
- * @returns {integer} - The current value of the LoP target field
+ * @returns {integer} The current value of the LoP target field
  */
 function getLoPTarget() {
   let targetsTab = browser.$('=Targets');
@@ -164,7 +164,7 @@ function getProgramIndicators(programName) {
 }
 
 /** Get a list of the program names in the Programs dropdown
- * Returns {Array<string>} - returns an array of the text strings making up the
+ * Returns {Array<string>} returns an array of the text strings making up the
  * Programs dropdown menu
  */
 function getProgramsList() {
@@ -178,7 +178,7 @@ function getProgramsList() {
 }
 
 /** Get a list of the program names in the main Program table
- * Returns {Array<string>} - returns an array of the text strings of the
+ * Returns {Array<string>} returns an array of the text strings of the
  * program names in the programs table
  */
 function getProgramsTable() {
@@ -191,7 +191,7 @@ function getProgramsTable() {
 }
 
 /** Get a list of the indicator buttons in the main programs table
- * Returns {Array<buttons>} - returns an array of clickable "buttons",
+ * Returns {Array<buttons>} returns an array of clickable "buttons",
  * which are actually anchor (<a />) elements, from the programs table
  */
 function getProgramIndicatorButtons() {
@@ -205,7 +205,7 @@ function getProgramIndicatorButtons() {
 
 /** Get the currently selected target frequency from the Target Frequency
  *  dropdown
- * @returns {string} - The currently selected target frequency as a text string
+ * @returns {string} The currently selected target frequency as a text string
  */
 function getTargetFrequency() {
   let targetsTab = browser.$('=Targets');
@@ -215,7 +215,7 @@ function getTargetFrequency() {
 }
 
 /** Get the current value of the Unit of measure text field
- * @returns {integer} - The current value as an integer
+ * @returns {integer} The current value as an integer
  */
 function getUnitOfMeasure() {
   let targetsTab = browser.$('=Targets');
@@ -225,7 +225,7 @@ function getUnitOfMeasure() {
 }
 
 /** Open the specified page in the browser
- * @param {string} url - The URL to display in the browser; defaults
+ * @param {string} url The URL to display in the browser; defaults
  * to the baseurl value from the config file
  * @returns Nothing
  */
@@ -235,7 +235,7 @@ function open(url = parms.baseurl) {
 
 // FIXME: This should be a property
 /** Return the page title
- * @returns {string} - The title of the current page
+ * @returns {string} The title of the current page
  */
 function pageName() {
   // On this page, the "title" is actually the <h2> caption
@@ -260,7 +260,7 @@ function saveNewIndicator() {
 }
 
 /** Select the specified program from the Programs dropdown
- * @param {string} program - The name of the program to select
+ * @param {string} program The name of the program to select
  * from the Programs dropdown menu
  * @returns Nothing
  */
@@ -278,7 +278,7 @@ function selectProgram(program) {
 
 /** Type a baseline value into the baseline text field on the Targets
  * tab unless the "Not applicable" check box has been checked
- * @param {integer|boolean} value - The non-negative integer baseline
+ * @param {integer|boolean} value The non-negative integer baseline
  * value. If set to false, ignore the baseline requirement and check
  * the "Not applicable" check box
  * @returns Nothing
@@ -303,7 +303,7 @@ function setBaselineNA() {
 
 /** Type the specified indicator name into the Name field on thei
  * Performance tab of the indicator detail screen
- * @param {string} name - The new name for the indicator
+ * @param {string} name The new name for the indicator
  * @returns Nothing
  */
 function setIndicatorName(name) {
@@ -315,7 +315,7 @@ function setIndicatorName(name) {
 
 /** Type LoP target value name into "Life of Program (LoP) target" text
  * field on the Targets tab of the indicator edit screen
- * @param {string} name - The new name for the indicator
+ * @param {string} name The new name for the indicator
  * @returns Nothing
  */
 function setLoPTarget(value) {
@@ -328,7 +328,7 @@ function setLoPTarget(value) {
 // FIXME: should not be hard-coding the value to select
 /** Select the target frequency from the Target Frequency dropdown on the
  *  the Targets tab of the indicator edit screen
- * @param {string} value - The target frequency to select from the dropdown
+ * @param {string} value The target frequency to select from the dropdown
  * @returns Nothing
  */
 function setTargetFrequency(value) {
@@ -340,7 +340,7 @@ function setTargetFrequency(value) {
 
 /** Type the unit of measure into the Unit of measure text field on
  * the Targets tab of the indicator edit screen
- * @param {string} unit - The new name for the indicator
+ * @param {string} unit The new name for the indicator
  * @returns Nothing
  */
 function setUnitOfMeasure(unit) {

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -1,5 +1,6 @@
 // indicators.page.js -- page object for testing the top-level Program
-// Indicators page
+// Indicators page object model; methods are listed in alphabetical order
+// so please help maintain that order.
 var util = require('../lib/testutil.js');
 
 var parms = util.readConfig();
@@ -37,8 +38,7 @@ function clickIndicatorsDropdown() {
  * @returns Nothing
  */
 function clickIndicatorsLink() {
-  browser.waitForText('h2');
-  browser.$('=Indicators').click();
+  browser.$('ul.nav.navbar-nav').$('=Indicators').click();
 }
 
 /** Click the Indicator Type dropdown
@@ -54,7 +54,7 @@ function clickIndicatorTypeDropdown() {
  * @returns Nothing
  */
 function clickNewIndicatorButton() {
-  browser.waitForVisible('=New Indicator', 1000);
+  browser.waitForVisible('=New Indicator');
   browser.$('=New Indicator').click();
 }
 
@@ -65,6 +65,9 @@ function clickProgramsDropdown() {
   browser.$('#dropdownProgram').click();
 }
 
+/** Clicks the Reset button on the current form
+ * @returns Nothing
+ */
 function clickResetButton() {
   browser.$('input[value="Reset"]').click();
 }
@@ -89,7 +92,8 @@ function createNewProgramIndicator(name, unit, lopTarget, baseline, frequency) {
 }
 
 /** Get the text of the current alert message, if any, and return it as a string
- * @returns {string} The current alert message as string
+ * @returns {string} The current alert message as a string. Fails ugly if the
+ * element isn't found.
  */
 function getAlertMsg() {
   let alertDiv = browser.$('div#alerts');
@@ -155,6 +159,10 @@ function getLoPTarget() {
   return val;
 }
 
+function getProgramIndicators(programName) {
+  selectProgram(programName);
+}
+
 /** Get a list of the program names in the Programs dropdown
  * Returns {Array<string>} - returns an array of the text strings making up the
  * Programs dropdown menu
@@ -182,6 +190,19 @@ function getProgramsTable() {
   return programs;
 }
 
+/** Get a list of the indicator buttons in the main programs table
+ * Returns {Array<buttons>} - returns an array of clickable "buttons",
+ * which are actually anchor (<a />) elements, from the programs table
+ */
+function getProgramIndicatorButtons() {
+  let rows = browser.$('div#toplevel_div').$$('div.panel-body');
+  let buttons = new Array();
+  for (let row of rows) {
+    buttons.push(row.$('a.btn.btn-sm.btn-success'));
+  }
+  return buttons;
+}
+
 /** Get the currently selected target frequency from the Target Frequency
  *  dropdown
  * @returns {string} - The currently selected target frequency as a text string
@@ -203,6 +224,24 @@ function getUnitOfMeasure() {
   return val;
 }
 
+/** Open the specified page in the browser
+ * @param {string} url - The URL to display in the browser; defaults
+ * to the baseurl value from the config file
+ * @returns Nothing
+ */
+function open(url = parms.baseurl) {
+  browser.url(url);
+}
+
+// FIXME: This should be a property
+/** Return the page title
+ * @returns {string} - The title of the current page
+ */
+function pageName() {
+  // On this page, the "title" is actually the <h2> caption
+  return browser.$('h2').getText();
+}
+
 /** Click the "Save changes" button on the Indicator edit screen
  * @returns Nothing
  */
@@ -220,10 +259,28 @@ function saveNewIndicator() {
   saveNew.click();
 }
 
+/** Select the specified program from the Programs dropdown
+ * @param {string} program - The name of the program to select
+ * from the Programs dropdown menu
+ * @returns Nothing
+ */
+function selectProgram(program) {
+  browser.$('#dropdownProgram').click();
+  let items = browser.$('div.btn-group').$('ul.dropdown-menu').$$('li>a');
+  for (let item of items) {
+    let s = item.getText();
+    if(s.includes(program)) {
+      item.click();
+      break;
+    }
+  }
+}
+
 /** Type a baseline value into the baseline text field on the Targets
  * tab unless the "Not applicable" check box has been checked
- * @param {integer|boolean} value - The integral value to be set or
- * "false" to ignore the baseline requirement
+ * @param {integer|boolean} value - The non-negative integer baseline
+ * value. If set to false, ignore the baseline requirement and check
+ * the "Not applicable" check box
  * @returns Nothing
  */
 function setBaseline(value = false) {
@@ -244,8 +301,8 @@ function setBaselineNA() {
   browser.$('#id_baseline_na').click()
 }
 
-/** Type an indicator name into the Name field on the Performance
- * tab of the indicator edit screen
+/** Type the specified indicator name into the Name field on thei
+ * Performance tab of the indicator detail screen
  * @param {string} name - The new name for the indicator
  * @returns Nothing
  */
@@ -293,40 +350,6 @@ function setUnitOfMeasure(unit) {
   bucket.setValue('Buckets');
 }
 
-/** Open the specified page in the browser
- * @param {string} url - The URL to display in the browser; defaults
- * to the baseurl value from the config file
- * @returns Nothing
- */
-function open(url = parms.baseurl) {
-  browser.url(url);
-}
-
-// FIXME: This should be a property
-/** Return the page title
- * @returns {string} - The title of the current page
- */
-function pageName() {
-  // On this page, the "title" is actually the <h2> caption
-  return browser.$('h2').getText();
-}
-
-/** Select the specified program from the Programs dropdown
- * @param {string} program - The name of the program to select
- * from the Programs dropdown menu
- * @returns Nothing
- */
-function selectProgram(program) {
-  browser.$('#dropdownProgram').click();
-  let items = browser.$('div.btn-group').$('ul.dropdown-menu').$$('li>a');
-  for (let item of items) {
-    if (program == item.getText()) {
-      item.click();
-      break;
-    }
-  }
-}
-
 exports.clickIndicatorDataButton = clickIndicatorDataButton;
 exports.clickIndicatorDeleteButton = clickIndicatorDeleteButton;
 exports.clickIndicatorEditButton = clickIndicatorEditButton;
@@ -343,6 +366,7 @@ exports.getIndicatorsList = getIndicatorsList;
 exports.getIndicatorName = getIndicatorName;
 exports.getIndicatorTypeList = getIndicatorTypeList;
 exports.getLoPTarget = getLoPTarget;
+exports.getProgramIndicatorButtons = getProgramIndicatorButtons;
 exports.getProgramsList = getProgramsList;
 exports.getProgramsTable = getProgramsTable;
 exports.getTargetFrequency = getTargetFrequency;

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -18,6 +18,10 @@ function clickIndicatorsDropdown() {
   browser.$('#dropdownIndicator').click();
 }
 
+function clickIndicatorsLink() {
+  browser.$('=Indicators').click();
+}
+
 function clickIndicatorTypeDropdown() {
   browser.$('#dropdownIndicatorType').click();
 }
@@ -29,6 +33,10 @@ function clickNewIndicatorButton() {
 
 function clickProgramsDropdown() {
   browser.$('#dropdownProgram').click();
+}
+
+function clickResetButton() {
+  browser.$('input[value="Reset"]').click();
 }
 
 function createNewProgramIndicator(name, unit, lopTarget, baseline, frequency) {
@@ -52,6 +60,26 @@ function getIndicatorsList() {
   return indicators;
 }
 
+function getAlertMsg() {
+  //let alertDiv = browser.$('div#alerts>div.alert.alert-danger.dynamic-alert.alert-dismissable');
+  let alertDiv = browser.$('div#alerts');
+  return alertDiv.$('p').getText();
+}
+
+function getBaseline() {
+  let targetsTab = browser.$('=Targets');
+  targetsTab.click();
+  let val = $('input#id_baseline').getValue();
+  return val;
+}
+
+function getIndicatorName() {
+  let targetsTab = browser.$('=Performance');
+  targetsTab.click();
+  let val = $('input#id_name').getValue();
+  return val;
+}
+
 function getIndicatorTypeList() {
   let list = browser.$('ul.dropdown-menu[aria-labelledby="dropdownIndicatorType"]');
   let listItems = list.$$('li>a');
@@ -60,6 +88,13 @@ function getIndicatorTypeList() {
     indicatorTypes.push(listItem.getText());
   }
   return indicatorTypes;
+}
+
+function getLoPTarget() {
+  let targetsTab = browser.$('=Targets');
+  targetsTab.click();
+  let val = $('input#id_lop_target').getValue();
+  return val;
 }
 
 function getProgramsList() {
@@ -79,6 +114,20 @@ function getProgramsTable() {
     programs.push(row.$('h4').getText());
   }
   return programs;
+}
+
+function getTargetFrequency() {
+  let targetsTab = browser.$('=Targets');
+  targetsTab.click();
+  let val = $('select#id_target_frequency').getValue();
+  return val;
+}
+
+function getUnitOfMeasure() {
+  let targetsTab = browser.$('=Targets');
+  targetsTab.click();
+  let val = $('input#id_unit_of_measure').getValue();
+  return val;
 }
 
 function saveIndicatorChanges() {
@@ -155,15 +204,23 @@ function selectProgram(program) {
 exports.clickIndicatorDataButton = clickIndicatorDataButton;
 exports.clickIndicatorDeleteButton = clickIndicatorDeleteButton;
 exports.clickIndicatorEditButton = clickIndicatorEditButton;
-exports.clickIndicatorsDropdown = clickIndicatorsDropdown;
 exports.clickIndicatorTypeDropdown = clickIndicatorTypeDropdown;
+exports.clickIndicatorsDropdown = clickIndicatorsDropdown;
+exports.clickIndicatorsLink = clickIndicatorsLink;
 exports.clickNewIndicatorButton = clickNewIndicatorButton;
 exports.clickProgramsDropdown = clickProgramsDropdown;
+exports.clickResetButton = clickResetButton;
 exports.createNewProgramIndicator = createNewProgramIndicator;
+exports.getAlertMsg = getAlertMsg;
+exports.getBaseline = getBaseline;
 exports.getIndicatorsList = getIndicatorsList;
+exports.getIndicatorName = getIndicatorName;
 exports.getIndicatorTypeList = getIndicatorTypeList;
+exports.getLoPTarget = getLoPTarget;
 exports.getProgramsList = getProgramsList;
 exports.getProgramsTable = getProgramsTable;
+exports.getTargetFrequency = getTargetFrequency;
+exports.getUnitOfMeasure = getUnitOfMeasure;
 exports.open = open;
 exports.pageName = pageName;
 exports.saveIndicatorChanges = saveIndicatorChanges;
@@ -176,7 +233,6 @@ exports.setBaseline = setBaseline;
 exports.setTargetFrequency = setTargetFrequency;
 
 /*
-exports.clickSaveChangesButton = clickSaveChangesButton;
 exports.clickPerformanceTab = clickPerformanceTab;
 exports.clickTargetsTab = clickTargetsTab;
 */

--- a/test/js/test/specs/indicators.js
+++ b/test/js/test/specs/indicators.js
@@ -110,17 +110,17 @@ describe('TolaActivity Program Indicators page', function() {
   });
 
   it('should have matching indicator counts on data button and in table', function() {
-    // FIXME: The hard pauses are a poor WAR for the button we want to click sometimes
-    // being occluded by another element.
+    // FIXME: The hard pause WARs, poorly, the situation in which the button
+    //        we want to click is sometimes, but not always, obscured by another element.
     let progIndTable = $('#toplevel_div');
     let buttons = progIndTable.$$('div.panel-body');
     for (let button of buttons) {
       let buttonCnt = parseInt(button.$('a').getText());
       let link = button.$('a');
       // expand the table
-      // FIXME: This is a horrible hack to accomodate a race.
+      // FIXME: This is a horrible hack to accommodate a race.
       // <div id="ajaxloading" class="modal ajax_loading" style="display: block;"></div>
-      // obscures the button we want to click, but how long varies because Internet.,
+      // obscures the button we want to click, but how long varies because Internet,
       // so hide the div. :-\
       browser.execute("document.getElementById('ajaxloading').style.visibility = 'hidden';");
       link.click();
@@ -142,20 +142,27 @@ describe('TolaActivity Program Indicators page', function() {
 
   describe('Program Indicators table', function() {
     it('should view PI by clicking its name in Indicator Name column', function() {
-		  browser.pause(500);
+      // Make list of Indicators buttons
+      let buttons = IndPage.getProgramIndicatorButtons();
+      // Click the first one to expand the table
+      let button = buttons[0];
+      button.click();
+      // Make list of indicator names in resulting table
+      // Click the first one
+
+      /*
 		  let progTable = IndPage.getProgramsTable();
 			let tableRow = progTable[1];
-			let link = $('='+tableRow);
+      let tableRowText = progTable[0].split('\n')[0].trim();
+			let link = $('=' + tableRowText);
 			link.click();
-      // FIXME: This is a horrible hack to accomodate a race.
-      // <div id="ajaxloading" class="modal ajax_loading" style="display: block;"></div>
-      // obscures the button we want to click, but how long varies because Internet.,
-      // so hide the div. :-\
+      // FIXME: This is the same horrible hack to accommodate a race.
       browser.waitForVisible('div#indicator_modal_header>h3');
       let dialogText = $('div#indicator_modal_header>h3').getText().split(':')[1].trim();
       assert.equal(rowText, dialogText, 'indicator name mismatch');
       let close = $('div#indicator_modal_div').$('button.close');
       close.click();
+      */
     });
 
     it('should be able to create PI by clicking the New Indicator button', function() {

--- a/test/js/test/specs/target.js
+++ b/test/js/test/specs/target.js
@@ -55,9 +55,8 @@ describe('Indicator Targets', function() {
     });
   }); // end new indicator dialog
 
-  // Test cases from Github #21, #24, #25, #30, #33, #35, #37, #42, #43
+  // Test cases from issues #21, #24, #25, #30, #33, #35, #37, #42, #43
   describe('Targets tab', function() {
-    // div.alerts>div.alert.alert-danger.dyanmic-alert.alert-dismissable>p
     it('should require "Unit of measure"', function() {
       // Set everything but the unit of measure then try to save
       IndPage.clickIndicatorsLink();
@@ -88,7 +87,7 @@ describe('Indicator Targets', function() {
                    'Did not receive expected failure message');
     });
 
-    it('should require Baseline for target unless "Not applicable" checked', function() {
+    it('should require target Baseline if "Not applicable" not checked', function() {
       // Set everything but the baseline value then try to save
       IndPage.clickIndicatorsLink();
       IndPage.clickNewIndicatorButton();
@@ -101,6 +100,24 @@ describe('Indicator Targets', function() {
       assert.equal('Please complete all required fields in the Targets tab.',
                    IndPage.getAlertMsg(),
                    'Did not receive expected failure message');
+    });
+
+    it('should *not* require target Baseline if "Not applicable" *is* checked', function() {
+      // Set everything but the baseline value
+      IndPage.clickIndicatorsLink();
+      IndPage.clickNewIndicatorButton();
+      IndPage.saveNewIndicator();
+      IndPage.setUnitOfMeasure('Bugs fixed');
+      IndPage.setLoPTarget(42);
+      IndPage.setTargetFrequency('Life of Program (LoP) only');
+      //, check "Not applicable" then try to save
+      IndPage.setBaselineNA();
+      browser.debug();
+      IndPage.saveIndicatorChanges();
+      // Should get this success message
+      assert.notEqual('Please complete all required fields in the Targets tab.',
+                       IndPage.getAlertMsg(),
+                       'Received unexpected error message');
     });
 
     it('should require Target frequency', function() {

--- a/test/js/test/specs/target.js
+++ b/test/js/test/specs/target.js
@@ -112,7 +112,6 @@ describe('Indicator Targets', function() {
       IndPage.setTargetFrequency('Life of Program (LoP) only');
       //, check "Not applicable" then try to save
       IndPage.setBaselineNA();
-      browser.debug();
       IndPage.saveIndicatorChanges();
       // Should get this success message
       assert.notEqual('Please complete all required fields in the Targets tab.',

--- a/test/js/test/specs/target.js
+++ b/test/js/test/specs/target.js
@@ -18,6 +18,7 @@ describe('Indicator Targets', function() {
   });
 
   describe('Create new indicator dialog', function() {
+    this.timeout(0);
     it('should open new indicator form when button is clicked', function() {
       IndPage.clickNewIndicatorButton();
       assert.equal('Create an Indicator', IndPage.pageName());
@@ -32,10 +33,10 @@ describe('Indicator Targets', function() {
     });
 
     it('should clear form when "Reset" button clicked', function() {
-      IndPage.setIndicatorName('testing LoP only target frequency');
-      IndPage.setUnitOfMeasure('Bugs fixed');
-      IndPage.setLoPTarget(42);
-      IndPage.setBaseline(2);
+      IndPage.setIndicatorName('Testing the reset button');
+      IndPage.setUnitOfMeasure('Clicks');
+      IndPage.setLoPTarget(61);
+      IndPage.setBaseline(62);
       IndPage.setTargetFrequency('Life of Program (LoP) only');
       IndPage.clickResetButton();
       assert.equal('Temporary', IndPage.getIndicatorName());
@@ -46,10 +47,10 @@ describe('Indicator Targets', function() {
     });
 
     it('should save data when "Save changes" button clicked', function() {
-      IndPage.setIndicatorName('testing LoP only target frequency');
-      IndPage.setUnitOfMeasure('Bugs fixed');
-      IndPage.setLoPTarget(42);
-      IndPage.setBaseline(2);
+      IndPage.setIndicatorName('Testing the save changes button');
+      IndPage.setUnitOfMeasure('Dashes');
+      IndPage.setLoPTarget(71);
+      IndPage.setBaseline(72);
       IndPage.setTargetFrequency('Life of Program (LoP) only');
       IndPage.saveIndicatorChanges();
     });
@@ -57,13 +58,15 @@ describe('Indicator Targets', function() {
 
   // Test cases from issues #21, #24, #25, #30, #33, #35, #37, #42, #43
   describe('Targets tab', function() {
+    this.timeout(0);
     it('should require "Unit of measure"', function() {
       // Set everything but the unit of measure then try to save
       IndPage.clickIndicatorsLink();
       IndPage.clickNewIndicatorButton();
       IndPage.saveNewIndicator();
-      IndPage.setLoPTarget(42);
-      IndPage.setBaseline(2);
+      IndPage.setIndicatorName('Unit of measure test');
+      IndPage.setLoPTarget(11);
+      IndPage.setBaseline(12);
       IndPage.setTargetFrequency('Life of Program (LoP) only');
       IndPage.saveIndicatorChanges();
       // Should get this error message
@@ -77,8 +80,8 @@ describe('Indicator Targets', function() {
       IndPage.clickIndicatorsLink();
       IndPage.clickNewIndicatorButton();
       IndPage.saveNewIndicator();
-      IndPage.setUnitOfMeasure('Bugs fixed');
-      IndPage.setBaseline(2);
+      IndPage.setUnitOfMeasure('LoP target test');
+      IndPage.setBaseline(21);
       IndPage.setTargetFrequency('Life of Program (LoP) only');
       IndPage.saveIndicatorChanges();
       // Should get this error message
@@ -92,8 +95,8 @@ describe('Indicator Targets', function() {
       IndPage.clickIndicatorsLink();
       IndPage.clickNewIndicatorButton();
       IndPage.saveNewIndicator();
-      IndPage.setUnitOfMeasure('Bugs fixed');
-      IndPage.setLoPTarget(42);
+      IndPage.setUnitOfMeasure('Baseline value test');
+      IndPage.setLoPTarget(31);
       IndPage.setTargetFrequency('Life of Program (LoP) only');
       IndPage.saveIndicatorChanges();
       // Should get this error message
@@ -107,13 +110,21 @@ describe('Indicator Targets', function() {
       IndPage.clickIndicatorsLink();
       IndPage.clickNewIndicatorButton();
       IndPage.saveNewIndicator();
-      IndPage.setUnitOfMeasure('Bugs fixed');
-      IndPage.setLoPTarget(42);
+      IndPage.setUnitOfMeasure('Baseline value not applicable test');
+      IndPage.setLoPTarget(41);
       IndPage.setTargetFrequency('Life of Program (LoP) only');
-      //, check "Not applicable" then try to save
+      // check "Not applicable" then try to save
       IndPage.setBaselineNA();
       IndPage.saveIndicatorChanges();
       // Should get this success message
+      // FIXME: This test fails because the success message is too fast;
+      //        I don't know how to catch it with WebDriver
+      assert.equal('Success, form data saved.',
+                   IndPage.getAlertMsg(),
+                   'Did not receive expected success message');
+      // Should not get this message
+      // FIXME: I'd rather not use the negative logic; much prefer the
+      //        positive form above if it can be made to work
       assert.notEqual('Please complete all required fields in the Targets tab.',
                        IndPage.getAlertMsg(),
                        'Received unexpected error message');
@@ -124,9 +135,9 @@ describe('Indicator Targets', function() {
       IndPage.clickIndicatorsLink();
       IndPage.clickNewIndicatorButton();
       IndPage.saveNewIndicator();
-      IndPage.setUnitOfMeasure('Bugs fixed');
+      IndPage.setUnitOfMeasure('Target frequency test');
       IndPage.setLoPTarget(42);
-      IndPage.setBaseline(2);
+      IndPage.setBaseline(43);
       IndPage.saveIndicatorChanges();
       // Should get this error message
       assert.equal('Please complete all required fields in the Targets tab.',

--- a/test/js/test/specs/target.js
+++ b/test/js/test/specs/target.js
@@ -18,96 +18,159 @@ describe('Indicator Targets', function() {
   });
 
   describe('Create new indicator dialog', function() {
-    it('should open the new indicator form when the button is clicked', function() {
+    it('should open new indicator form when button is clicked', function() {
       IndPage.clickNewIndicatorButton();
       assert.equal('Create an Indicator', IndPage.pageName());
+    });
+
+    it('should save the new indicator when the button is clicked', function() {
       IndPage.saveNewIndicator();
-      IndPage.setIndicatorName('testing LoP only target frequency')
+    });
+
+    it('should have a "Reset" button', function() {
+      IndPage.clickResetButton();
+    });
+
+    it('should clear form when "Reset" button clicked', function() {
+      IndPage.setIndicatorName('testing LoP only target frequency');
+      IndPage.setUnitOfMeasure('Bugs fixed');
+      IndPage.setLoPTarget(42);
+      IndPage.setBaseline(2);
+      IndPage.setTargetFrequency('Life of Program (LoP) only');
+      IndPage.clickResetButton();
+      assert.equal('Temporary', IndPage.getIndicatorName());
+      assert.equal('', IndPage.getUnitOfMeasure());
+      assert.equal('', IndPage.getLoPTarget());
+      assert.equal('', IndPage.getBaseline());
+      assert.equal('', IndPage.getTargetFrequency());
+    });
+
+    it('should save data when "Save changes" button clicked', function() {
+      IndPage.setIndicatorName('testing LoP only target frequency');
       IndPage.setUnitOfMeasure('Bugs fixed');
       IndPage.setLoPTarget(42);
       IndPage.setBaseline(2);
       IndPage.setTargetFrequency('Life of Program (LoP) only');
       IndPage.saveIndicatorChanges();
     });
-
-    it('should accept no value for "Sector"');
-    it('should accept any value for "Sector"');
-    it('should require "Program Objective"');
-    it('should require "Country Strategic Objection"');
-    it('should have a "Save changes" button');
-    it('should have a "Reset" button');
-    it('should have a "Help" button');
-    it('should open the "Targets" tab when clicked');
-    it('should clear form when "Reset" button clicked');
-    it('should save data when "Save changes" button clicked');
   }); // end new indicator dialog
 
   // Test cases from Github #21, #24, #25, #30, #33, #35, #37, #42, #43
   describe('Targets tab', function() {
-    it('should require "Unit of measure"');
-    it('should require "Life of Program (LoP) target" value');
-    it('should not require Rationale for target');
-    it('should require Baseline for target unless "Not applicable" checked');
-    it('should clear form when Reset button clicked');
-    it('should save data when Save changes button clicked');
+    // div.alerts>div.alert.alert-danger.dyanmic-alert.alert-dismissable>p
+    it('should require "Unit of measure"', function() {
+      // Set everything but the unit of measure then try to save
+      IndPage.clickIndicatorsLink();
+      IndPage.clickNewIndicatorButton();
+      IndPage.saveNewIndicator();
+      IndPage.setLoPTarget(42);
+      IndPage.setBaseline(2);
+      IndPage.setTargetFrequency('Life of Program (LoP) only');
+      IndPage.saveIndicatorChanges();
+      // Should get this error message
+      assert.equal('Please complete all required fields in the Targets tab.',
+                   IndPage.getAlertMsg(),
+                   'Did not receive expected failure message');
+    });
 
-    describe('Target frequency', function() {
-      it('should be a required selection');
-      it('should require selecting Target frequency');
-      it('should have 8 options on Target frequency selection menu');
+    it('should require "Life of Program (LoP) target" value', function() {
+      // Set everything but the LoP target then try to save
+      IndPage.clickIndicatorsLink();
+      IndPage.clickNewIndicatorButton();
+      IndPage.saveNewIndicator();
+      IndPage.setUnitOfMeasure('Bugs fixed');
+      IndPage.setBaseline(2);
+      IndPage.setTargetFrequency('Life of Program (LoP) only');
+      IndPage.saveIndicatorChanges();
+      // Should get this error message
+      assert.equal('Please complete all required fields in the Targets tab.',
+                   IndPage.getAlertMsg(),
+                   'Did not receive expected failure message');
+    });
 
-      describe('"Life of Program (LoP) only" target frequency', function() {
-        it('should permit only numeric values for LoP target');
-        it('should reject non-numeric values for LoP target');
-        it('should permit non-numeric values only in legacy data for LoP target');
-        it('should require numeric value for LoP target if non-numeric legacy data is modified');
-      });
+    it('should require Baseline for target unless "Not applicable" checked', function() {
+      // Set everything but the baseline value then try to save
+      IndPage.clickIndicatorsLink();
+      IndPage.clickNewIndicatorButton();
+      IndPage.saveNewIndicator();
+      IndPage.setUnitOfMeasure('Bugs fixed');
+      IndPage.setLoPTarget(42);
+      IndPage.setTargetFrequency('Life of Program (LoP) only');
+      IndPage.saveIndicatorChanges();
+      // Should get this error message
+      assert.equal('Please complete all required fields in the Targets tab.',
+                   IndPage.getAlertMsg(),
+                   'Did not receive expected failure message');
+    });
 
-      describe('"Midline and endline" target frequency', function() {
-        it('should show Midline and endline targets form after clicking Create targets button');
-        it('should clear Midline and endline targets form after clicking Remove all targets button');
-        it('should show Midline and endline target table');
-        it('should require value in Midline target field');
-        it('should require value in Endline target field');
-        it('should not permit removing only midline or endline targets');
-        it('should require removing both targets to remove either one');
-        it('should require Midline target if freq is midline and endline')
-        it('should require Endline target if freq is midline and endline')
-      });
+    it('should require Target frequency', function() {
+      // Set everything but the target frequency then try to save
+      IndPage.clickIndicatorsLink();
+      IndPage.clickNewIndicatorButton();
+      IndPage.saveNewIndicator();
+      IndPage.setUnitOfMeasure('Bugs fixed');
+      IndPage.setLoPTarget(42);
+      IndPage.setBaseline(2);
+      IndPage.saveIndicatorChanges();
+      // Should get this error message
+      assert.equal('Please complete all required fields in the Targets tab.',
+                   IndPage.getAlertMsg(),
+                   'Did not receive expected failure message');
+    });
 
-      describe('"Annual" target frequency', function() {
-        it('should require value for Annual target if freq is annual');
-      });
+    it('should have 8 options on Target frequency selection menu');
 
-      describe('"Semi-annual" target frequency', function() {
-        it('should require Semi-annual target if freq is semi-annual');
-      });
+    describe('"Life of Program (LoP) only" target frequency', function() {
+      it('should permit only numeric values for LoP target');
+      it('should reject non-numeric values for LoP target');
+      it('should permit non-numeric values only in legacy data for LoP target');
+      it('should require numeric value for LoP target if non-numeric legacy data is modified');
+    });
 
-      describe('"Tri-annual" target frequency', function() {
-        it('should require Tri-annual target if freq is tri-annual');
-      });
+    describe('"Midline and endline" target frequency', function() {
+      it('should show Midline and endline targets form after clicking Create targets button');
+      it('should clear Midline and endline targets form after clicking Remove all targets button');
+      it('should show Midline and endline target table');
+      it('should require value in Midline target field');
+      it('should require value in Endline target field');
+      it('should not permit removing only midline or endline targets');
+      it('should require removing both targets to remove either one');
+      it('should require Midline target if freq is midline and endline');
+      it('should require Endline target if freq is midline and endline');
+    });
 
-      describe('"Quarterly" target frequency', function() {
-        it('should require Quarterly target if freq is quarterly');
-      });
+    describe('"Annual" target frequency', function() {
+      it('should require value for Annual target if freq is annual');
+    });
 
-      describe('"Monthly" target frequency', function() {
-        it('should require Monthly target if freq is monthly');
-      });
+    describe('"Semi-annual" target frequency', function() {
+      it('should require Semi-annual target if freq is semi-annual');
+    });
 
-      describe('"Event" target frequency', function() {
-        it('should require name of first event if Target frequency is Event');
-        it('should require number of events if Target frequency is Event');
-        it('should require at least one event if Target frequency is Event');
-        it('should permit adding up to 12 events if Target frequency is Event');
-        it('should inform user that only 12 events can be created at once');
-        it('should create table of event-based targets when Create targets button is clicked');
-        it('should require First event name if freq is Event');
-        it('should require Number of events if freq is Event');
-        it('should require only numeric value for Number of events');
-        it('should default Number of events to 1');
-        it('should limit Number of events between 1 and 12');
-      });
+    describe('"Tri-annual" target frequency', function() {
+      it('should require Tri-annual target if freq is tri-annual');
+    });
+
+    describe('"Quarterly" target frequency', function() {
+      it('should require Quarterly target if freq is quarterly');
+    });
+
+    describe('"Monthly" target frequency', function() {
+      it('should require Monthly target if freq is monthly');
+    });
+
+    describe('"Event" target frequency', function() {
+      it('should require name of first event if Target frequency is Event');
+      it('should require number of events if Target frequency is Event');
+      it('should require at least one event if Target frequency is Event');
+      it('should permit adding up to 12 events if Target frequency is Event');
+      it('should inform user that only 12 events can be created at once');
+      it('should create table of event-based targets when Create targets button is clicked');
+      it('should require First event name if freq is Event');
+      it('should require Number of events if freq is Event');
+      it('should require only numeric value for Number of events');
+      it('should default Number of events to 1');
+      it('should limit Number of events between 1 and 12');
     });
 
     it('should have Create targets button');
@@ -115,7 +178,7 @@ describe('Indicator Targets', function() {
     it('should require target frequency options before enabling Create targets button');
     it('should enable type-to-search in the Target frequency selection menu');
     it('should require First target period if using periodic indicators');
-    it('should require Number of target periods if using periodic indicators')
+    it('should require Number of target periods if using periodic indicators');
     it('should require only numeric value for Number of target periods');
     it('should default Number of target periods to 1');
     it('should prompt user if any required field is empty');


### PR DESCRIPTION
Add minimal JSDoc tags to the indicators and login page objects (_test/js/test/pages/indicators.page.js_ and _test/js/test/pages/login.page.js_, respectively). Add a Makefile to produce the documentation on demand. Type `make help` for complete information. Resulting docs available in _test/js/doc/_.