### PR TITLE
Update page objects and test logic

### DIFF
--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -14,6 +14,14 @@ parms.baseurl += '/indicators/home/0/0/0';
  * Click the Indicators dropdown button
  * @returns Nothing
  */
+/*
+> $$('span.select2-selection--single')[0].getText()
+'Filter by program'
+> $$('span.select2-selection--single')[1].getText()
+'Filter by indicator'
+> $$('span.select2-selection--single')[2].getText()
+'Filter by indicator type'
+*/
 function clickIndicatorsDropdown() {
   let span = $('span.select2-selection--single');
   let indicatorsDropdown = span.$('span#select2-id_indicators_filter_dropdown-container');
@@ -34,7 +42,7 @@ function clickIndicatorsLink() {
  */
 function clickIndicatorTypeDropdown() {
   let span = $('span.select2-selection--single');
-  let indicatorsDropdown = span.$('span#select2-id_indicatortypes_filter_dropdown-container');
+  let indicatorTypesDropdown = span.$('span#select2-id_indicatortypes_filter_dropdown-container');
   indicatorTypesDropdown.click();
 }
 
@@ -88,8 +96,8 @@ function getIndicatorTypeList() {
   let listItems = selectList.$$('option');
   let indicatorTypes = new Array();
   for (let listItem of listItems) {
+    let s = listItem.getText();
     if (! s.includes('-- All --')) {
-      let s = listItem.getText();
       indicatorTypes.push(s);
     }
   }

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -16,7 +16,7 @@ parms.baseurl += '/indicators/home/0/0/0';
  */
 function clickIndicatorsDropdown() {
   let span = $('span.select2-selection--single');
-  let indicatorsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
+  let indicatorsDropdown = span.$('span#select2-id_indicators_filter_dropdown-container');
   indicatorsDropdown.click();
 }
 
@@ -34,7 +34,7 @@ function clickIndicatorsLink() {
  */
 function clickIndicatorTypeDropdown() {
   let span = $('span.select2-selection--single');
-  let indicatorsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
+  let indicatorsDropdown = span.$('span#select2-id_indicatortypes_filter_dropdown-container');
   indicatorTypesDropdown.click();
 }
 
@@ -84,11 +84,14 @@ function getIndicatorName() {
  * indicator types dropdown menu
  */
 function getIndicatorTypeList() {
-  let list = browser.$('ul#' + indtypes_filter);
-  let listItems = list.$$('li>a');
+  let selectList = browser.$('select#id_indicatortypes_filter_dropdown');
+  let listItems = selectList.$$('option');
   let indicatorTypes = new Array();
   for (let listItem of listItems) {
-    indicatorTypes.push(listItem.getText());
+    if (! s.includes('-- All --')) {
+      let s = listItem.getText();
+      indicatorTypes.push(s);
+    }
   }
   return indicatorTypes;
 }
@@ -99,18 +102,21 @@ function getIndicatorTypeList() {
  * indicators dropdown menu
  */
 function getIndicatorsDropdownList() {
-  let list = browser.$('ul#' + inds_filter);
-  let listItems = list.$$('li>a');
+  let selectList = browser.$('select#id_indicators_filter_dropdown');
+  let listItems = selectList.$$('option');
   let indicators = new Array();
   for (let listItem of listItems) {
-    indicators.push(listItem.getText());
+    let s = listItem.getText();
+    if (! s.includes('-- All --')) {
+      indicators.push(s);
+    }
   }
   return indicators;
 }
 
 /**
  * Get a list of the programs Programs dropdown. If which is empty or "strings",
- * returns a list of the names; if which is "links" or anything else, return the 
+ * returns a list of the names; if which is "links" or anything else, return the
  * list as clickable links so they can be selected.
  * @returns {Array<string>|<link>} an array of either the text strings making up the
  * Programs dropdown menu or the actual clickable links on the Programs dropdown menu
@@ -120,13 +126,15 @@ function getProgramsDropdownList() {
   //let programsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
   //let dropdownList = browser.$('select#id_programs_filter_dropdown');
   //let listItems = list.$$('li>a');
-  let selectList = browser.$('select#id_programs_filter_dropdown')
+  let selectList = browser.$('select#id_programs_filter_dropdown');
   let listItems = selectList.$$('option');
   let programs = new Array();
   for (let listItem of listItems) {
-    programs.push(listItem.getText());
-  }
-	return programs;
+    let s = listItem.getText();
+    if (! s.includes('-- All --'))
+      programs.push(s);
+    }
+    return programs;
 }
 
 /**
@@ -138,7 +146,8 @@ function getProgramsTable() {
   let rows = browser.$('div#toplevel_div').$$('div.panel-heading');
   let programs = new Array();
   for(let row of rows) {
-    programs.push(row.$('h4').getText());
+    let s = row.$('h4').getText();
+    programs.push(s);
   }
   return programs;
 }
@@ -171,13 +180,18 @@ function pageName() {
  */
 function selectProgram(program) {
   clickProgramsDropdown();
-  let listItems = getProgramsDropdownList();
+  let selectList = browser.$('select#id_programs_filter_dropdown');
+  let listItems = selectList.$$('option');
+  let programs = new Array();
   for (let listItem of listItems) {
-    if(listItem.includes(program)) {
-      listItems.selectByVisibleText(program);
+    let s = listItem.getText();
+    let v = listItem.getValue();
+    if (s.includes(program)) {
+      selectList.selectByValue(v);
       break;
     }
   }
+  clickProgramsDropdown();
 }
 
 exports.clickIndicatorsDropdown = clickIndicatorsDropdown;

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -14,18 +14,11 @@ parms.baseurl += '/indicators/home/0/0/0';
  * Click the Indicators dropdown button
  * @returns Nothing
  */
-/*
-> $$('span.select2-selection--single')[0].getText()
-'Filter by program'
-> $$('span.select2-selection--single')[1].getText()
-'Filter by indicator'
-> $$('span.select2-selection--single')[2].getText()
-'Filter by indicator type'
-*/
 function clickIndicatorsDropdown() {
-  let span = $('span.select2-selection--single');
-  let indicatorsDropdown = span.$('span#select2-id_indicators_filter_dropdown-container');
-  indicatorsDropdown.click();
+  // $$('span.select2-selection--single')[0].getText()
+  // 'Filter by program'
+  let span = browser.$$('span.select2-selection--single')[1];
+  span.click();
 }
 
 /**
@@ -41,9 +34,8 @@ function clickIndicatorsLink() {
  * @returns Nothing
  */
 function clickIndicatorTypeDropdown() {
-  let span = $('span.select2-selection--single');
-  let indicatorTypesDropdown = span.$('span#select2-id_indicatortypes_filter_dropdown-container');
-  indicatorTypesDropdown.click();
+  let span = $$('span.select2-selection--single')[2];
+  span.click();
 }
 
 /**
@@ -51,9 +43,8 @@ function clickIndicatorTypeDropdown() {
  * @returns Nothing
  */
 function clickProgramsDropdown() {
-  let span = $('span.select2-selection--single');
-  let programsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
-  programsDropdown.click();
+  let span = $$('span.select2-selection--single')[0];
+  span.click();
 }
 
 /**

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -7,7 +7,6 @@
 const msec = 1000;
 
 var util = require('../lib/testutil.js');
-
 var parms = util.readConfig();
 parms.baseurl += '/indicators/home/0/0/0';
 
@@ -16,7 +15,9 @@ parms.baseurl += '/indicators/home/0/0/0';
  * @returns Nothing
  */
 function clickIndicatorsDropdown() {
-  browser.$('#dropdownIndicator').click();
+  let span = $('span.select2-selection--single');
+  let indicatorsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
+  indicatorsDropdown.click();
 }
 
 /**
@@ -32,15 +33,19 @@ function clickIndicatorsLink() {
  * @returns Nothing
  */
 function clickIndicatorTypeDropdown() {
-  browser.$('#dropdownIndicatorType').click();
+  let span = $('span.select2-selection--single');
+  let indicatorsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
+  indicatorTypesDropdown.click();
 }
 
 /**
- * Click the Programs dropdown
+ * Click the Programs dropdown button
  * @returns Nothing
  */
 function clickProgramsDropdown() {
-  browser.$('#dropdownProgram').click();
+  let span = $('span.select2-selection--single');
+  let programsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
+  programsDropdown.click();
 }
 
 /**
@@ -79,7 +84,7 @@ function getIndicatorName() {
  * indicator types dropdown menu
  */
 function getIndicatorTypeList() {
-  let list = browser.$('ul.dropdown-menu[aria-labelledby="dropdownIndicatorType"]');
+  let list = browser.$('ul#' + indtypes_filter);
   let listItems = list.$$('li>a');
   let indicatorTypes = new Array();
   for (let listItem of listItems) {
@@ -94,7 +99,7 @@ function getIndicatorTypeList() {
  * indicators dropdown menu
  */
 function getIndicatorsDropdownList() {
-  let list = browser.$('ul.dropdown-menu[aria-labelledby="dropdownIndicator"]');
+  let list = browser.$('ul#' + inds_filter);
   let listItems = list.$$('li>a');
   let indicators = new Array();
   for (let listItem of listItems) {
@@ -104,21 +109,23 @@ function getIndicatorsDropdownList() {
 }
 
 /**
- * Get a list of the program names in the Programs dropdown
- * @returns {Array<string>} returns an array of the text strings making up the
- * Programs dropdown menu
+ * Get a list of the programs Programs dropdown. If which is empty or "strings",
+ * returns a list of the names; if which is "links" or anything else, return the 
+ * list as clickable links so they can be selected.
+ * @returns {Array<string>|<link>} an array of either the text strings making up the
+ * Programs dropdown menu or the actual clickable links on the Programs dropdown menu
  */
 function getProgramsDropdownList() {
-	clickProgramsDropdown();
-  let list = browser.$('ul.dropdown-menu[aria-labelledby="dropdownProgram"]');
-  let listItems = list.$$('li>a');
+  //let span = $('span.select2-selection--single');
+  //let programsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
+  //let dropdownList = browser.$('select#id_programs_filter_dropdown');
+  //let listItems = list.$$('li>a');
+  let selectList = browser.$('select#id_programs_filter_dropdown')
+  let listItems = selectList.$$('option');
   let programs = new Array();
   for (let listItem of listItems) {
-	  if (! listItem.getText().includes('-- All --')) {
-	    programs.push(listItem.getText());
-		}
+    programs.push(listItem.getText());
   }
-	clickProgramsDropdown();
 	return programs;
 }
 
@@ -163,12 +170,11 @@ function pageName() {
  * @returns Nothing
  */
 function selectProgram(program) {
-  browser.$('#dropdownProgram').click();
-  let items = browser.$('div.btn-group').$('ul.dropdown-menu').$$('li>a');
-  for (let item of items) {
-    let s = item.getText();
-    if(s.includes(program)) {
-      item.click();
+  clickProgramsDropdown();
+  let listItems = getProgramsDropdownList();
+  for (let listItem of listItems) {
+    if(listItem.includes(program)) {
+      listItems.selectByVisibleText(program);
       break;
     }
   }

--- a/test/js/test/specs/indicators.js
+++ b/test/js/test/specs/indicators.js
@@ -121,14 +121,29 @@ describe('TolaActivity Program Indicators page', function() {
 		IndPage.clickIndicatorsLink();
     let buttons = TargetsTab.getProgramIndicatorButtons();
     for (let button of buttons) {
+      // Get indicator count from the button
       let buttonCnt = parseInt(button.getText());
       let targetDiv = button.getAttribute('data-target');
+
       // Expand the table
       button.click();
+		  if(browser.isVisible('div#ajaxloading')) {
+			  browser.waitForVisible('div#ajaxloading', delay, true);
+		  }
+
       // Get indicator count from table
-      let table = $('='+targetDiv).$('table');
+      let table = $('div.panel-heading').$('div.panel-body').$('table');
+      let rows = table.$('tbody').$$('tr>td>a.indicator-link');
+      let tableCnt = rows.length;
+
       // collapse the table
+			if (browser.isVisible('div#ajaxloading')) {
+				browser.waitForVisible('div#ajaxloading', delay, true);
+		  }
       button.click();
+
+      // Should be the same count
+      assert.equal(buttonCnt, tableCnt, 'Indicator count mismatch with table count');
     }
   }, 3); // Try this flaky test up to 3 times before failing
 

--- a/test/js/test/specs/indicators.js
+++ b/test/js/test/specs/indicators.js
@@ -26,7 +26,7 @@ describe('TolaActivity Program Indicators page', function() {
   describe('Programs dropdown', function() {
     it('should be present on page', function() {
 			if (browser.isVisible('div#ajaxloading')) {
-				browser.execute("document.getElementById('ajaxloading').style.visibility = 'hidden';");
+				browser.waitForVisible('div#ajaxloading', delay, true);
 		  }
       IndPage.clickProgramsDropdown();
       IndPage.clickProgramsDropdown();
@@ -55,13 +55,14 @@ describe('TolaActivity Program Indicators page', function() {
 
     it('should filter programs table by selected program name', function() {
       let progList = IndPage.getProgramsDropdownList();
-      let listItem = progList[0];
-      IndPage.selectProgram(listItem);
+      let prog = progList[0]
+      IndPage.selectProgram(prog);
 
       // should have a single row in the table
       let progTable = IndPage.getProgramsTable();
       // row should be the one selected from the dropdown
       let rowText = progTable[0].split('\n')[0].trim();
+      browser.debug();
       let listText = listItem.split('-')[1].trim();
       assert.equal(rowText, listText, 'program name mismtach');
     });

--- a/test/js/test/specs/indicators.js
+++ b/test/js/test/specs/indicators.js
@@ -53,19 +53,16 @@ describe('TolaActivity Program Indicators page', function() {
       };
     });
 
-    it('should filter programs table by selected program name', function() {
-      let progList = IndPage.getProgramsDropdownList();
-      let prog = progList[0]
-      IndPage.selectProgram(prog);
-
-      // should have a single row in the table
-      let progTable = IndPage.getProgramsTable();
-      // row should be the one selected from the dropdown
-      let rowText = progTable[0].split('\n')[0].trim();
-      browser.debug();
-      let listText = listItem.split('-')[1].trim();
-      assert.equal(rowText, listText, 'program name mismtach');
-    });
+		it('should filter programs table by selected program name', function() {
+			let selectList = browser.$('select#id_programs_filter_dropdown');
+			let progTable = selectList.$$('options');
+			for (let listItem of progTable) {
+				let s = listItem.getText();
+				if (! s.includes('-- All --')) {
+					browser.selectByVisibleText(s);
+				}
+			}
+		});
   }); // end programs dropdown tests
 
   describe('Indicators dropdown', function() {

--- a/test/js/wdio.conf.js
+++ b/test/js/wdio.conf.js
@@ -43,7 +43,7 @@ exports.config = {
         // grid with only 5 firefox instances available you can make sure that not more than
         // 5 instances get started at a time.
         maxInstances: 5,
-        browserName: 'chrome'
+        browserName: 'firefox'
     }],
     //
     // ===================


### PR DESCRIPTION
After changes to the Indicators page for release 1.9.4, it was necessary to modify the page objects to accommodate the changes and fix a few tests that still know too much about their underlying pages.