### PR TITLE
Fix page objects to work with new Indicators page

### DIFF
--- a/test/js/Makefile
+++ b/test/js/Makefile
@@ -16,7 +16,7 @@ update-all:
 	@cd node_modules && npm update --dev --save && cd ..
 
 clean:
-	@rm -fvr doc errorShots node_modules selenium-server.log
+	@rm -fvr doc errorShots node_modules selenium-server.log server.log
 
 server:
 	@java -jar \

--- a/test/js/delete.js
+++ b/test/js/delete.js
@@ -7,6 +7,7 @@ const msec = 1000;
 describe('Deleting a lot of indicators', function() {
   // Disable timeouts
   this.timeout(0);
+  browser.windowHandleMaximize();
 
   it('should delete a PI by clicking its Delete button', function() {
     let parms = util.readConfig();
@@ -22,13 +23,14 @@ describe('Deleting a lot of indicators', function() {
     }
     IndPage.selectProgram('Tola Rollout');
     let indButtons = TargetsTab.getProgramIndicatorButtons();
+    IndPage.clickProgramsDropdown();
     indButtons[0].click();
 
     let indicatorList, indicator, confirmBtn
     let deleteCnt = 0;
     let indicatorCount = TargetsTab.getProgramIndicatorsTableCount();
     let buttons = new Array();
-    while (indicatorCount > 6) {
+    while (indicatorCount > 8) {
       indicatorList = TargetsTab.getProgramIndicatorsTable();
       indicator = indicatorList.shift();
       indicator.click();

--- a/test/js/delete.js
+++ b/test/js/delete.js
@@ -21,13 +21,14 @@ describe('Deleting a lot of indicators', function() {
       browser.waitForVisible('div#ajaxloading', true, 10*msec);
     }
     IndPage.selectProgram('Tola Rollout');
-    let buttons = TargetsTab.getProgramIndicatorButtons();
-    buttons[0].click();
+    let indButtons = TargetsTab.getProgramIndicatorButtons();
+    indButtons[0].click();
 
     let indicatorList, indicator, confirmBtn
     let deleteCnt = 0;
     let indicatorCount = TargetsTab.getProgramIndicatorsTableCount();
-    while (indicatorCount > 8) {
+    let buttons = new Array();
+    while (indicatorCount > 6) {
       indicatorList = TargetsTab.getProgramIndicatorsTable();
       indicator = indicatorList.shift();
       indicator.click();

--- a/test/js/package.json
+++ b/test/js/package.json
@@ -1,24 +1,24 @@
 {
-	"scripts": {
-		"test": "mocha --require babel-register --es_staging --harmony"
-	},
-	"devDependencies": {
-		"babel-cli": "^6.26.0",
-		"babel-preset-env": "^1.6.1",
-		"babel-preset-es2015": "^6.24.1",
-		"babel-register": "^6.26.0",
-		"chai": "^4.1.2",
-		"jsdoc": "^3.5.5",
-		"mocha": "^4.1.0",
-		"selenium-webdriver": "^3.6.0",
-		"wdio-mocha-framework": "^0.5.12",
-		"wdio-spec-reporter": "^0.1.3",
-		"webdriverio": "^4.10.2"
-	},
-	"dependencies": {
-		"readable-stream": "^2.3.4",
-		"string_decoder": "^1.0.3"
-	},
-	"repository": "https://github.com/mercycorps/TolaActivity.git",
-	"license": "Apache-2.0"
+  "scripts": {
+    "test": "mocha --require babel-register --es_staging --harmony"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-register": "^6.26.0",
+    "chai": "^4.1.2",
+    "jsdoc": "^3.5.5",
+    "mocha": "^4.1.0",
+    "selenium-webdriver": "^3.6.0",
+    "wdio-mocha-framework": "^0.5.12",
+    "wdio-spec-reporter": "^0.1.3",
+    "webdriverio": "^4.10.2"
+  },
+  "dependencies": {
+    "readable-stream": "^2.3.4",
+    "string_decoder": "^1.0.3"
+  },
+  "repository": "https://github.com/mercycorps/TolaActivity.git",
+  "license": "Apache-2.0"
 }

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -23,7 +23,7 @@ parms.baseurl += '/indicators/home/0/0/0';
 'Filter by indicator type'
 */
 function clickIndicatorsDropdown() {
-  let span = $('span.select2-selection--single');
+  let span = $$('span.select2-selection--single')[1];
   let indicatorsDropdown = span.$('span#select2-id_indicators_filter_dropdown-container');
   indicatorsDropdown.click();
 }
@@ -41,7 +41,7 @@ function clickIndicatorsLink() {
  * @returns Nothing
  */
 function clickIndicatorTypeDropdown() {
-  let span = $('span.select2-selection--single');
+  let span = $$('span.select2-selection--single')[2];
   let indicatorTypesDropdown = span.$('span#select2-id_indicatortypes_filter_dropdown-container');
   indicatorTypesDropdown.click();
 }
@@ -51,7 +51,7 @@ function clickIndicatorTypeDropdown() {
  * @returns Nothing
  */
 function clickProgramsDropdown() {
-  let span = $('span.select2-selection--single');
+  let span = $$('span.select2-selection--single')[0];
   let programsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
   programsDropdown.click();
 }

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -14,11 +14,18 @@ parms.baseurl += '/indicators/home/0/0/0';
  * Click the Indicators dropdown button
  * @returns Nothing
  */
+/*
+> $$('span.select2-selection--single')[0].getText()
+'Filter by program'
+> $$('span.select2-selection--single')[1].getText()
+'Filter by indicator'
+> $$('span.select2-selection--single')[2].getText()
+'Filter by indicator type'
+*/
 function clickIndicatorsDropdown() {
-  // $$('span.select2-selection--single')[0].getText()
-  // 'Filter by program'
-  let span = browser.$$('span.select2-selection--single')[1];
-  span.click();
+  let span = $('span.select2-selection--single');
+  let indicatorsDropdown = span.$('span#select2-id_indicators_filter_dropdown-container');
+  indicatorsDropdown.click();
 }
 
 /**
@@ -34,8 +41,9 @@ function clickIndicatorsLink() {
  * @returns Nothing
  */
 function clickIndicatorTypeDropdown() {
-  let span = $$('span.select2-selection--single')[2];
-  span.click();
+  let span = $('span.select2-selection--single');
+  let indicatorTypesDropdown = span.$('span#select2-id_indicatortypes_filter_dropdown-container');
+  indicatorTypesDropdown.click();
 }
 
 /**
@@ -43,8 +51,9 @@ function clickIndicatorTypeDropdown() {
  * @returns Nothing
  */
 function clickProgramsDropdown() {
-  let span = $$('span.select2-selection--single')[0];
-  span.click();
+  let span = $('span.select2-selection--single');
+  let programsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
+  programsDropdown.click();
 }
 
 /**

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -4,24 +4,25 @@
  */
 // Methods are listed in alphabetical order; please help
 // keep them that way. Thanks!
-const msec = 1000;
 
 var util = require('../lib/testutil.js');
 var parms = util.readConfig();
+
+// milliseconds
+const msec = 1000;
 parms.baseurl += '/indicators/home/0/0/0';
+
+/*
+ * dropdowns = $$('span.select2-selection--single');
+ * programsDropdown = dropdowns[0];
+ * indicatorsDropdown = dropdowns[1];
+ * indicatorTypesDropdown = dropdowns[2]
+*/
 
 /**
  * Click the Indicators dropdown button
  * @returns Nothing
  */
-/*
-> $$('span.select2-selection--single')[0].getText()
-'Filter by program'
-> $$('span.select2-selection--single')[1].getText()
-'Filter by indicator'
-> $$('span.select2-selection--single')[2].getText()
-'Filter by indicator type'
-*/
 function clickIndicatorsDropdown() {
   let span = $$('span.select2-selection--single')[1];
   let indicatorsDropdown = span.$('span#select2-id_indicators_filter_dropdown-container');
@@ -33,7 +34,9 @@ function clickIndicatorsDropdown() {
  * @returns Nothing
  */
 function clickIndicatorsLink() {
-  browser.$('ul.nav.navbar-nav').$('=Indicators').click();
+  let indicatorsLink = browser.$('ul.nav.navbar-nav').$('=Indicators');
+  indicatorsLink.click();
+  browser.waitForVisible('h2=Program Indicators');
 }
 
 /**
@@ -75,9 +78,9 @@ function getAlertMsg() {
 }
 
 /**
- * Get the current indicator name (from the Performance tab)
- * @returns {string} The current value of the indicator name from the Performance
- * tab of the indicator detail screen
+ * Get the current indicator name (from the Performance tab) on the indicator
+ * detail screen
+ * @returns {string} The indicator name
  */
 function getIndicatorName() {
   let targetsTab = browser.$('=Performance');
@@ -122,6 +125,14 @@ function getIndicatorsDropdownList() {
   return indicators;
 }
 
+/**
+ * Get the number of program indicators for the table in a div named
+ * targetId. This is the program indicators table for the the given
+ * program.
+ * @param {string} targetId The target div containing the table you
+ * want to enumerate
+ * @returns {integer} The number of indicators in the specified table
+ */
 function getProgramIndicatorsTableCount(targetId) {
   let tableDiv = $('div#toplevel_div').$('div.panel');
   let table = tableDiv.$(targetId).$('table.hiddenTable');
@@ -137,15 +148,11 @@ function getProgramIndicatorsTableCount(targetId) {
 }
 
 /**
- * Get a list of the programs Programs dropdown.
- * @returns {Array<string>} an array of the text strings making up the Programs 
+ * Get a list of the program name in the Programs dropdown.
+ * @returns {Array<string>} an array of the text strings in the Programs 
  * dropdown menu
  */
 function getProgramsDropdownList() {
-  //let span = $('span.select2-selection--single');
-  //let programsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
-  //let dropdownList = browser.$('select#id_programs_filter_dropdown');
-  //let listItems = list.$$('li>a');
   let selectList = browser.$('select#id_programs_filter_dropdown');
   let listItems = selectList.$$('option');
   let programs = new Array();
@@ -158,7 +165,7 @@ function getProgramsDropdownList() {
 }
 
 /**
- * Get a list of the program names in the main Program table
+ * Get a list of the program names in the main Programs table
  * @returns {Array<string>} returns an array of the text strings of the
  * program names in the programs table
  */
@@ -200,7 +207,7 @@ function pageName() {
  */
 function selectProgram(program) {
   clickProgramsDropdown();
-  let span = $('span.select2-selection--single');
+  let span = $$('span.select2-selection--single')[0];
   let programsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
   let listItems = programsDropdown.$$('option');
   for (let listItem of listItems) {

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -122,6 +122,20 @@ function getIndicatorsDropdownList() {
   return indicators;
 }
 
+function getProgramIndicatorsTableCount(targetId) {
+  let tableDiv = $('div#toplevel_div').$('div.panel');
+  let table = tableDiv.$(targetId).$('table.hiddenTable');
+  let rows = table.$$('tbody>tr>td>a');
+  let rowCnt = 0;
+  for (let row of rows) {
+    let text = row.getText();
+    if (text.length > 0) {
+      rowCnt++;
+    }
+  }
+  return rowCnt;
+}
+
 /**
  * Get a list of the programs Programs dropdown.
  * @returns {Array<string>} an array of the text strings making up the Programs 
@@ -208,6 +222,7 @@ exports.getAlertMsg = getAlertMsg;
 exports.getIndicatorName = getIndicatorName;
 exports.getIndicatorTypeList = getIndicatorTypeList;
 exports.getIndicatorsDropdownList = getIndicatorsDropdownList;
+exports.getProgramIndicatorsTableCount = getProgramIndicatorsTableCount;
 exports.getProgramsDropdownList = getProgramsDropdownList;
 exports.getProgramsTable = getProgramsTable;
 exports.open = open;

--- a/test/js/test/pages/indicators.page.js
+++ b/test/js/test/pages/indicators.page.js
@@ -123,11 +123,9 @@ function getIndicatorsDropdownList() {
 }
 
 /**
- * Get a list of the programs Programs dropdown. If which is empty or "strings",
- * returns a list of the names; if which is "links" or anything else, return the
- * list as clickable links so they can be selected.
- * @returns {Array<string>|<link>} an array of either the text strings making up the
- * Programs dropdown menu or the actual clickable links on the Programs dropdown menu
+ * Get a list of the programs Programs dropdown.
+ * @returns {Array<string>} an array of the text strings making up the Programs 
+ * dropdown menu
  */
 function getProgramsDropdownList() {
   //let span = $('span.select2-selection--single');
@@ -188,9 +186,9 @@ function pageName() {
  */
 function selectProgram(program) {
   clickProgramsDropdown();
-  let selectList = browser.$('select#id_programs_filter_dropdown');
-  let listItems = selectList.$$('option');
-  let programs = new Array();
+  let span = $('span.select2-selection--single');
+  let programsDropdown = span.$('span#select2-id_programs_filter_dropdown-container');
+  let listItems = programsDropdown.$$('option');
   for (let listItem of listItems) {
     let s = listItem.getText();
     let v = listItem.getValue();
@@ -199,7 +197,6 @@ function selectProgram(program) {
       break;
     }
   }
-  clickProgramsDropdown();
 }
 
 exports.clickIndicatorsDropdown = clickIndicatorsDropdown;

--- a/test/js/test/pages/login.page.js
+++ b/test/js/test/pages/login.page.js
@@ -3,7 +3,8 @@
  * @module login
  */
 
-/** Opens a browser window and navigates to the requested URL
+/**
+ * Opens a browser window and navigates to the requested URL
  * @param {string} url - The URL to which to navigate
  * @returns Nothing
  */
@@ -11,7 +12,8 @@ function open(url) {
   browser.url(url);
 }
 
-/** Types the specified username into the username text box
+/**
+ * Types the specified username into the username text box
  * @param {string} username - The login name to use
  * @returns Nothing
  */
@@ -20,7 +22,8 @@ function setUserName(username) {
   loginBox.setValue(username);
 }
 
-/** Types the specified password into the password text box
+/**
+ * Types the specified password into the password text box
  * @param {string} password - The password to use
  * @returns Nothing
  */
@@ -29,7 +32,8 @@ function setPassword(password) {
   passwordBox.setValue(password);
 }
 
-/** Clicks the login button on the sign-in page
+/**
+ * Clicks the login button on the sign-in page
  * @returns Nothing
  */
 function clickLoginButton() {

--- a/test/js/test/pages/targets.page.js
+++ b/test/js/test/pages/targets.page.js
@@ -71,8 +71,21 @@ function clickProgramIndicatorsButton(programName) {
   // click it
 }
 
+/***
+ * Click the Reset button on the current form to clear any changes
+ * @returns Nothing
+ */
 function clickResetButton() {
   browser.$('input[value="Reset"]').click();
+}
+
+/**
+ * Click the Targets tab of the Indicator detail modal or page
+ * @returns Nothing
+ */
+function clickTargetsTab() {
+  let targetsTab = browser.$('=Targets');
+  targetsTab.click();
 }
 
 /**
@@ -114,8 +127,9 @@ function getAlertMsg() {
  * @returns {integer} The current value of the Baseline text field
  */
 function getBaseline() {
-  let targetsTab = browser.$('=Targets');
-  targetsTab.click();
+  //let targetsTab = browser.$('=Targets');
+  //targetsTab.click();
+  clickTargetsTab();
   let val = $('input#id_baseline').getValue();
   return val;
 }
@@ -249,7 +263,14 @@ function getTargetFrequency() {
   let targetsTab = browser.$('=Targets');
   targetsTab.click();
   let val = $('select#id_target_frequency').getValue();
-  return val;
+  if (val == 0) {
+    return '---------';
+  } else {
+    let list = $('select#id_target_frequency').getText();
+    let rows = list.split('\n');
+    let result = rows[val];
+    return result.trim();
+  }
 }
 
 function getTargetFirstPeriodErrorHint() {
@@ -307,6 +328,9 @@ function pageName() {
 function saveIndicatorChanges() {
   let saveChanges = $('input[value="Save changes"]');
   saveChanges.click();
+  if (browser.isVisible('id.alerts')) {
+    browser.waitForVisible('id.alerts', delay, true);
+  }
 }
 
 /**
@@ -440,7 +464,7 @@ function setUnitOfMeasure(unit) {
   let targetsTab = browser.$('=Targets');
   targetsTab.click();
   let bucket = $('input#id_unit_of_measure');
-  bucket.setValue('Buckets');
+  bucket.setValue(unit);
 }
 
 exports.clickIndicatorDataButton = clickIndicatorDataButton;

--- a/test/js/test/specs/indicators.js
+++ b/test/js/test/specs/indicators.js
@@ -121,29 +121,14 @@ describe('TolaActivity Program Indicators page', function() {
 		IndPage.clickIndicatorsLink();
     let buttons = TargetsTab.getProgramIndicatorButtons();
     for (let button of buttons) {
-      // Get indicator count from the button
       let buttonCnt = parseInt(button.getText());
       let targetDiv = button.getAttribute('data-target');
-
       // Expand the table
       button.click();
-		  if(browser.isVisible('div#ajaxloading')) {
-			  browser.waitForVisible('div#ajaxloading', delay, true);
-		  }
-
       // Get indicator count from table
-      let table = $('div.panel-heading').$('div.panel-body').$('table');
-      let rows = table.$('tbody').$$('tr>td>a.indicator-link');
-      let tableCnt = rows.length;
-
+      let table = $('='+targetDiv).$('table');
       // collapse the table
-			if (browser.isVisible('div#ajaxloading')) {
-				browser.waitForVisible('div#ajaxloading', delay, true);
-		  }
       button.click();
-
-      // Should be the same count
-      assert.equal(buttonCnt, tableCnt, 'Indicator count mismatch with table count');
     }
   }, 3); // Try this flaky test up to 3 times before failing
 

--- a/test/js/test/specs/indicators.js
+++ b/test/js/test/specs/indicators.js
@@ -25,9 +25,9 @@ describe('TolaActivity Program Indicators page', function() {
 
   describe('Programs dropdown', function() {
     it('should be present on page', function() {
-			if (browser.isVisible('div#ajaxloading')) {
-				browser.waitForVisible('div#ajaxloading', delay, true);
-		  }
+      if (browser.isVisible('div#ajaxloading')) {
+        browser.waitForVisible('div#ajaxloading', delay, true);
+      }
       IndPage.clickProgramsDropdown();
       IndPage.clickProgramsDropdown();
     });
@@ -53,16 +53,16 @@ describe('TolaActivity Program Indicators page', function() {
       };
     });
 
-		it('should filter programs table by selected program name', function() {
-			let selectList = browser.$('select#id_programs_filter_dropdown');
-			let progTable = selectList.$$('options');
-			for (let listItem of progTable) {
-				let s = listItem.getText();
-				if (! s.includes('-- All --')) {
-					browser.selectByVisibleText(s);
-				}
-			}
-		});
+    it('should filter programs table by selected program name', function() {
+      let selectList = browser.$('select#id_programs_filter_dropdown');
+      let progTable = selectList.$$('options');
+      for (let listItem of progTable) {
+        let s = listItem.getText();
+        if (! s.includes('-- All --')) {
+          browser.selectByVisibleText(s);
+        }
+      }
+    });
   }); // end programs dropdown tests
 
   describe('Indicators dropdown', function() {
@@ -115,26 +115,30 @@ describe('TolaActivity Program Indicators page', function() {
 
   // FIXME: Still need to get WebDriver code out of this test
   it('should have matching indicator counts on data button and in table', function() {
-		if(browser.isVisible('div#ajaxloading')) {
-			browser.waitForVisible('div#ajaxloading', delay, true);
-		}
-		IndPage.clickIndicatorsLink();
+    if(browser.isVisible('div#ajaxloading')) {
+      browser.waitForVisible('div#ajaxloading', delay, true);
+    }
+    IndPage.clickIndicatorsLink();
     let buttons = TargetsTab.getProgramIndicatorButtons();
     for (let button of buttons) {
       let buttonCnt = parseInt(button.getText());
-      let targetDiv = button.getAttribute('data-target');
-      // Expand the table
       button.click();
-      // Get indicator count from table
-      let table = $('='+targetDiv).$('table');
-      // collapse the table
+      if(browser.isVisible('div#ajaxloading')) {
+        browser.waitForVisible('div#ajaxloading', delay, true);
+      }
+      let targetId = button.getAttribute('data-target');
+      let tableCnt = IndPage.getProgramIndicatorsTableCount(targetId);
+      assert.equal(buttonCnt, tableCnt, "Indicator count mismatch");
       button.click();
+      if(browser.isVisible('div#ajaxloading')) {
+        browser.waitForVisible('div#ajaxloading', delay, true);
+      }
     }
   }, 3); // Try this flaky test up to 3 times before failing
 
   describe('Program Indicators table', function() {
     it('should view PI by clicking its name in Indicator Name column', function() {
-			IndPage.clickIndicatorsLink();
+      IndPage.clickIndicatorsLink();
       // Make list of Indicators buttons
       let buttons = TargetsTab.getProgramIndicatorButtons();
       // Click the first one to expand the table
@@ -144,9 +148,9 @@ describe('TolaActivity Program Indicators page', function() {
       // FIXME: needs to be from table, not dropdown
       let indicatorNameList = IndPage.getIndicatorsDropdownList();
       // Click the first one
-			if (browser.isVisible('div#ajaxloading')) {
-				browser.execute("document.getElementById('ajaxloading').style.visibility = 'hidden';");
-		  }
+      if (browser.isVisible('div#ajaxloading')) {
+        browser.execute("document.getElementById('ajaxloading').style.visibility = 'hidden';");
+      }
       let indicatorName = indicatorNameList[0];
       TargetsTab.clickProgramIndicatorsButton(indicatorName);
     });

--- a/test/js/test/specs/targets.js
+++ b/test/js/test/specs/targets.js
@@ -45,19 +45,47 @@ describe('Indicator Targets', function() {
       assert.equal('', TargetsTab.getUnitOfMeasure());
       assert.equal('', TargetsTab.getLoPTarget());
       assert.equal('', TargetsTab.getBaseline());
-      assert.equal('', TargetsTab.getTargetFrequency());
+      assert.equal('---------', TargetsTab.getTargetFrequency());
     });
 
-    it('should save data when "Save changes" button clicked', function() {
+    it('should save changed data when "Save changes" button clicked', function() {
+      // Create a new "basic" indicator
       IndPage.clickIndicatorsLink();
-      TargetsTab.createNewProgramIndicator('Testing the createNewProgramIndicator method', 
-        'Dashes', 52, 53, 'Life of Program (LoP) only');
+      TargetsTab.clickNewIndicatorButton();
+      TargetsTab.saveNewIndicator();
+
+      // Make a bunch of changes
+      let newIndicatorName = 'Testing the save changes button';
+      let newUnitOfMeasure = 'Leaps per lightyear';
+      let newLoPTarget = 57;
+      let newBaseline = 58;
+      let newTargetFrequency = 'Life of Program (LoP) only';
+
+      TargetsTab.setIndicatorName(newIndicatorName);
+      TargetsTab.setUnitOfMeasure(newUnitOfMeasure);
+      TargetsTab.setLoPTarget(newLoPTarget);
+      TargetsTab.setBaseline(newBaseline);
+      TargetsTab.setTargetFrequency(newTargetFrequency);
+
+      // Save them
+      TargetsTab.saveIndicatorChanges();
+
+      // Verify the new values are correct
+      assert.equal(newIndicatorName, TargetsTab.getIndicatorName(),
+        'Did not receive expected indicator name');
+      assert.equal(newUnitOfMeasure, TargetsTab.getUnitOfMeasure(),
+        'Did not receive expected unit of measure');
+      assert.equal(newLoPTarget, TargetsTab.getLoPTarget(),
+        'Did not receive expected LoP target');
+      assert.equal(newBaseline, TargetsTab.getBaseline(),
+        'Did not receive expected baseline value');
+      assert.equal(newTargetFrequency, TargetsTab.getTargetFrequency(),
+        'Did not receive expected target frequency');
     });
   }); // end new indicator dialog
 
   // Test cases from issues #21, #24, #25, #30, #33, #35, #37, #42, #43
   describe('Targets tab', function() {
-    this.timeout(0);
     it('should require "Unit of measure"', function() {
       // Set everything but the unit of measure then try to save
       IndPage.clickIndicatorsLink();

--- a/test/js/wdio.conf.js
+++ b/test/js/wdio.conf.js
@@ -43,7 +43,7 @@ exports.config = {
         // grid with only 5 firefox instances available you can make sure that not more than
         // 5 instances get started at a time.
         maxInstances: 5,
-        browserName: 'chrome'
+        browserName: 'firefox'
     }],
     //
     // ===================

--- a/test/js/wdio.conf.js
+++ b/test/js/wdio.conf.js
@@ -32,7 +32,7 @@ exports.config = {
     // and 30 processes will get spawned. The property handles how many capabilities
     // from the same test should run tests.
     //
-    maxInstances: 2,
+    maxInstances: 3,
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:

--- a/test/js/wdio.conf.js
+++ b/test/js/wdio.conf.js
@@ -32,7 +32,7 @@ exports.config = {
     // and 30 processes will get spawned. The property handles how many capabilities
     // from the same test should run tests.
     //
-    maxInstances: 1,
+    maxInstances: 2,
     //
     // If you have trouble getting all important capabilities together, check out the
     // Sauce Labs platform configurator - a great tool to configure your capabilities:
@@ -43,7 +43,7 @@ exports.config = {
         // grid with only 5 firefox instances available you can make sure that not more than
         // 5 instances get started at a time.
         maxInstances: 5,
-        browserName: 'firefox'
+        browserName: 'chrome'
     }],
     //
     // ===================


### PR DESCRIPTION
Updates to the Indicators page required updates to the underlying page objects used to test for that page. This is that update. Test status is back to 2 pre-existing failures.