### PR TITLE
mc/issues/175 Test periodic target date ranges

### DIFF
--- a/test/js/package.json
+++ b/test/js/package.json
@@ -9,6 +9,7 @@
 		"babel-preset-es2015": "^6.24.1",
 		"babel-register": "^6.26.0",
 		"chai": "^4.1.2",
+		"date-arithmetic": "^3.1.0",
 		"jsdoc": "^3.5.5",
 		"mocha": "^4.1.0",
 		"selenium-webdriver": "^3.6.0",

--- a/test/js/test/pages/targets.page.js
+++ b/test/js/test/pages/targets.page.js
@@ -88,6 +88,22 @@ function getBaselineErrorHint() {
   return errorHint;
 }
 
+function getTargetDateRanges() {
+    browser.pause(msec);
+    browser.scroll('h5');
+    let placeholder = browser.$('div#id_div_periodic_tables_placeholder');
+    let targetsDiv = placeholder.$('div#periodic-targets-tablediv');
+    let targetsTable = targetsDiv.$('table#periodic_targets_table');
+    let rows = targetsTable.$$('tbody>tr.periodic-target');
+
+    let dateRanges = new Array();
+    for (let row of rows) {
+        let dateRange = row.$('div').getText();
+        dateRanges.push(dateRange.trim());
+    }
+    return dateRanges;
+}
+
 /**
  * Get the current indicator name (from the Performance tab)
  * @returns {string} The current value of the indicator name from the Performance
@@ -421,9 +437,9 @@ function setFirstEventName(value) {
  */
 function setFirstTargetPeriod() {
   // Defaults to the current month
+  browser.scroll('input#id_target_frequency_start');
   browser.$('input#id_target_frequency_start').click();
   browser.$('button.ui-datepicker-close').click();
-  //browser.moveToObject('input#target_frequency_num_periods');
 }
 
 /**
@@ -536,6 +552,7 @@ exports.getIndicatorName = getIndicatorName;
 exports.getLoPErrorHint = getLoPErrorHint;
 exports.getLoPTarget = getLoPTarget;
 exports.getNumTargetEvents = getNumTargetEvents;
+exports.getNumTargetEventsErrorHint = getNumTargetEventsErrorHint;
 exports.getNumTargetPeriods = getNumTargetPeriods;
 exports.getProgramIndicatorsTable = getProgramIndicatorsTable;
 exports.getProgramIndicatorsTableCount = getProgramIndicatorsTableCount;
@@ -543,11 +560,11 @@ exports.getProgramIndicatorDeleteButtons = getProgramIndicatorDeleteButtons;
 exports.getProgramIndicatorEditButtons = getProgramIndicatorEditButtons;
 exports.getProgramIndicatorButtons = getProgramIndicatorButtons;
 exports.getProgramsTable = getProgramsTable;
+exports.getTargetDateRanges = getTargetDateRanges;
 exports.getTargetFirstEventErrorHint = getTargetFirstEventErrorHint;
 exports.getTargetFirstPeriodErrorHint = getTargetFirstPeriodErrorHint;
 exports.getTargetFrequency = getTargetFrequency;
 exports.getTargetInputBoxes = getTargetInputBoxes;
-exports.getNumTargetEventsErrorHint = getNumTargetEventsErrorHint;
 exports.getTargetValueErrorHint = getTargetValueErrorHint;
 exports.getUnitOfMeasure = getUnitOfMeasure;
 exports.open = open;

--- a/test/js/test/specs/periodic_date_ranges.js
+++ b/test/js/test/specs/periodic_date_ranges.js
@@ -1,0 +1,157 @@
+import { assert, expect } from 'chai';
+import IndPage from '../pages/indicators.page';
+import LoginPage from '../pages/login.page';
+import NavBar from '../pages/navbar.page';
+import TargetsTab from '../pages/targets.page';
+import Util from '../lib/testutil';
+import DateMath from 'date-arithmetic';
+
+const msec = 1000;
+const delay = 10*msec;
+'use strict';
+
+describe('Periodic target date ranges', function() {
+    before(function() {
+      // Disable timeouts
+      this.timeout(0);
+      //browser.windowHandleMaximize();
+      let parms = Util.readConfig();
+                          
+      LoginPage.open(parms.baseurl);
+      if (parms.baseurl.includes('mercycorps.org')) {
+          LoginPage.username = parms.username;
+          LoginPage.password = parms.password;
+          LoginPage.login.click();
+      } else if (parms.baseurl.includes('localhost')) {
+          LoginPage.googleplus.click();
+          if (LoginPage.title != 'TolaActivity') {
+              LoginPage.gUsername = parms.username + '@mercycorps.org';
+              LoginPage.gPassword = parms.password;
+          }
+      }
+    });
+
+    it('for annual periodic targets should be correct', function() {
+        NavBar.Indicators.click();    
+        IndPage.createBasicIndicator();
+        TargetsTab.setTargetFrequency('Annual');
+        // Set first period to current month
+        TargetsTab.setFirstTargetPeriod();
+        // Set number of target periods to 2
+        TargetsTab.setNumTargetPeriods(2);
+        // Set other required values
+        TargetsTab.setUnitOfMeasure('Apples per apiary');
+        TargetsTab.setLoPTarget(43);
+        TargetsTab.setBaseline(44);
+        // Save changes
+        TargetsTab.saveIndicatorChanges();
+
+        // Validation:
+        let dateRanges = TargetsTab.getTargetDateRanges();
+        let rangeStart, rangeEnd, diff;
+        for (let dateRange of dateRanges) {
+            rangeStart = new Date(dateRange.split(' - ')[0]);
+            rangeEnd = new Date(dateRange.split(' - ')[1]);
+            //FIXME: code smell
+            diff = DateMath.diff(rangeStart, rangeEnd, 'year', true);
+            expect(Math.round(diff) == 1);
+        }
+    });
+
+    it('for semi-annual periodic targets should be correct', function() {
+        NavBar.Indicators.click();    
+        IndPage.createBasicIndicator();
+        TargetsTab.setTargetFrequency('Semi-annual');
+        TargetsTab.setFirstTargetPeriod();
+        TargetsTab.setNumTargetPeriods(3);
+        TargetsTab.setUnitOfMeasure('Bees per bonnet');
+        TargetsTab.setLoPTarget(70);
+        TargetsTab.setBaseline(71);
+        // Save changes
+        TargetsTab.saveIndicatorChanges();
+
+        // Validation:
+        let dateRanges = TargetsTab.getTargetDateRanges();
+        let rangeStart, rangeEnd, diff;
+        for (let dateRange of dateRanges) {
+            rangeStart = new Date(dateRange.split(' - ')[0]);
+            rangeEnd = new Date(dateRange.split(' - ')[1]);
+            //FIXME: code smell
+            diff = DateMath.diff(rangeStart, rangeEnd, 'month', true);
+            expect(Math.round(diff) == 6);
+        }
+    });
+
+    it('for tri-annual periodic targets should be correct', function() {
+        NavBar.Indicators.click();    
+        IndPage.createBasicIndicator();
+        TargetsTab.setTargetFrequency('Tri-annual');
+        TargetsTab.setFirstTargetPeriod();
+        TargetsTab.setNumTargetPeriods(4);
+        TargetsTab.setUnitOfMeasure('Cats per cradle');
+        TargetsTab.setLoPTarget(92);
+        TargetsTab.setBaseline(93);
+        // Save changes
+        TargetsTab.saveIndicatorChanges();
+
+        // Validation:
+        let dateRanges = TargetsTab.getTargetDateRanges();
+        let rangeStart, rangeEnd, diff;
+        for (let dateRange of dateRanges) {
+            rangeStart = new Date(dateRange.split(' - ')[0]);
+            rangeEnd = new Date(dateRange.split(' - ')[1]);
+            //FIXME: code smell
+            diff = DateMath.diff(rangeStart, rangeEnd, 'month', true);
+            expect(Math.round(diff) == 4);
+        }
+    });
+
+    it('for quarterly periodic targets should be correct', function() {
+        NavBar.Indicators.click();    
+        IndPage.createBasicIndicator();
+        TargetsTab.setTargetFrequency('Quarterly');
+        TargetsTab.setFirstTargetPeriod();
+        TargetsTab.setNumTargetPeriods(5);
+        TargetsTab.setUnitOfMeasure('Doodles per desk');
+        TargetsTab.setLoPTarget(116);
+        TargetsTab.setBaseline(117);
+        // Save changes
+        TargetsTab.saveIndicatorChanges();
+
+        // Validation:
+        let dateRanges = TargetsTab.getTargetDateRanges();
+        let rangeStart, rangeEnd, diff;
+        for (let dateRange of dateRanges) {
+            rangeStart = new Date(dateRange.split(' - ')[0]);
+            rangeEnd = new Date(dateRange.split(' - ')[1]);
+            //FIXME: code smell
+            diff = DateMath.diff(rangeStart, rangeEnd, 'month', true);
+            expect(Math.round(diff) == 3);
+        }
+    });
+
+    it('for monthly periodic targets should be correct', function() {
+        NavBar.Indicators.click();    
+        IndPage.createBasicIndicator();
+        TargetsTab.setTargetFrequency('Tri-annual');
+        TargetsTab.setFirstTargetPeriod();
+        TargetsTab.setNumTargetPeriods(4);
+        TargetsTab.setUnitOfMeasure('Egrets per egress');
+        TargetsTab.setLoPTarget(140);
+        TargetsTab.setBaseline(141);
+        // Save changes
+        TargetsTab.saveIndicatorChanges();
+
+        // Validation:
+        let dateRanges = TargetsTab.getTargetDateRanges();
+        let rangeStart, rangeEnd, diff;
+        for (let dateRange of dateRanges) {
+            rangeStart = new Date(dateRange.split(' - ')[0]);
+            rangeEnd = new Date(dateRange.split(' - ')[1]);
+            //FIXME: code smell
+            diff = DateMath.diff(rangeStart, rangeEnd, 'month', true);
+            expect(Math.round(diff) == 1);
+        }
+    });
+});
+


### PR DESCRIPTION
Perform basic validation of date ranges created for periodic targets. This required adding an additional JS library, _date-arithmetic_, to save me from having to write yet another date-handling library. This commit covers the first bulleted test in #175 :
> Create Periodic Targets (annual, semi-annual, Tri-annual, quarterly, and monthly) and ensure that the date ranges associated with each target is correct.