### PR TITLE
Tweak Indicator UI, related to #209

### DIFF
--- a/templates/indicators/indicator_form_helper.html
+++ b/templates/indicators/indicator_form_helper.html
@@ -550,14 +550,14 @@
     function toggleCummulativeOptions(unit_of_measure_type) {
         // the top option is always the default option
         if (unit_of_measure_type == 2) {
-            $("#id_span_is_cumulative_header").text("PERCENTAGE (%) INDICATORS");
+            $("#id_span_is_cumulative_header h4").text("{% trans "PERCENTAGE (%) INDICATORS" %}");
             show_hide_cummulative_inputs('percent')
             $("#id_is_cumulative_1").prop("checked", false);
             // Although it's not displayed, when the measurement type is cumulative, the input should be set to true
             // so the is_cumulative input can be submitted with the correct value
             $("#id_is_cumulative_2").prop("checked", true);
         } else {
-            $("#id_span_is_cumulative_header").text("OPTIONS FOR NUMBER (#) INDICATORS");
+            $("#id_span_is_cumulative_header h4").text("{% trans "OPTIONS FOR NUMBER (#) INDICATORS" %}");
             show_hide_cummulative_inputs('number')
             $("#id_is_cumulative_1").prop("checked", true);
             $("#id_is_cumulative_2").prop("checked", false);

--- a/templates/indicators/indicator_form_helper.html
+++ b/templates/indicators/indicator_form_helper.html
@@ -550,14 +550,14 @@
     function toggleCummulativeOptions(unit_of_measure_type) {
         // the top option is always the default option
         if (unit_of_measure_type == 2) {
-            $("#id_span_is_cumulative_header h4").text("{% trans "PERCENTAGE (%) INDICATORS" %}");
+            $("#id_span_is_cumulative_header h4").text("{% trans 'PERCENTAGE (%) INDICATORS' %}");
             show_hide_cummulative_inputs('percent')
             $("#id_is_cumulative_1").prop("checked", false);
             // Although it's not displayed, when the measurement type is cumulative, the input should be set to true
             // so the is_cumulative input can be submitted with the correct value
             $("#id_is_cumulative_2").prop("checked", true);
         } else {
-            $("#id_span_is_cumulative_header h4").text("{% trans "OPTIONS FOR NUMBER (#) INDICATORS" %}");
+            $("#id_span_is_cumulative_header h4").text("{% trans 'OPTIONS FOR NUMBER (#) INDICATORS' %}");
             show_hide_cummulative_inputs('number')
             $("#id_is_cumulative_1").prop("checked", true);
             $("#id_is_cumulative_2").prop("checked", false);

--- a/templates/indicators/indicator_form_helper.html
+++ b/templates/indicators/indicator_form_helper.html
@@ -645,7 +645,9 @@
             $("#id_span_targtsaggregate_percent_sign").text("");
             $("#id_span_loptarget_percent_sign").text("");
         }
-
+        else{
+            $("#id_span_loptarget_percent_sign").text("%");
+        }
     }
 
     $( document ).ready(function() {

--- a/templates/indicators/indicatortargets.html
+++ b/templates/indicators/indicatortargets.html
@@ -29,7 +29,7 @@
                         </td>
 
                         <td class="align-middle" align="right" width="150px">
-                            <span id="id_span_{{ pt.id }}" class="{% if indicator.unit_of_measure_type == 2 %}input-symbol-percent{% endif %}"">
+                            <span id="id_span_{{ pt.id }}" class="{% if indicator.unit_of_measure_type == 2 %}input-symbol-percent{% endif %}">
                                 <input
                                     type="number"
                                     id="pt-{{ pt.id }}"

--- a/templates/indicators/indicatortargets.html
+++ b/templates/indicators/indicatortargets.html
@@ -92,7 +92,7 @@
                             <strong>
                                 <span id="id_span_loptarget">
                                     {{indicator.lop_target|floatformat:"-2" }}
-                                    <span id="id_span_loptarget_percent_sign">
+                                    <span id="id_span_loptarget_percent_sign" style="margin-left: -.20rem">
                                         {% if indicator.unit_of_measure_type == 2 %}%{% endif %}
                                     </span>
                                 </span>
@@ -123,9 +123,9 @@
                             <strong>
                                 <span id="id_span_is_cumulative_header">
                                     {% if unit_type == 1 %}
-                                        {% trans "OPTIONS FOR NUMBER (#) INDICATORS" %}
+                                        <h4>{% trans "OPTIONS FOR NUMBER (#) INDICATORS" %}</h4>
                                     {% else %}
-                                        {% trans "PERCENTAGE (%) INDICATORS" %}
+                                        <h4>{% trans "PERCENTAGE (%) INDICATORS" %}</h4>
                                     {% endif %}
                                 </span>
                             </strong>


### PR DESCRIPTION
Also fix a small bug introduced in #253 fix that eliminated the % sign being shown after the LOP Target.