### PR TITLE
Fix bug in cumulative/non-cumulative display

### DIFF
--- a/static/css/app_bootstrap_overrides.css
+++ b/static/css/app_bootstrap_overrides.css
@@ -85,7 +85,9 @@ body > .container {
     border-color: #00A49F;
     color: #FFFFFF;
     font-size: 1.125rem;
+    font-weight: bold;
     box-shadow: none;
+    text-transform: uppercase;
 }
 
 .btn-primary:not(:disabled):not(.disabled).active,
@@ -114,7 +116,9 @@ body > .container {
     border-color: #00A49F;
     color: #00A49F;
     font-size: 1.125rem;
+    font-weight: bold;
     box-shadow: none;
+    text-transform: uppercase;
 }
 
 .btn-secondary:not(:disabled):not(.disabled).active,

--- a/templates/indicators/indicator_form_helper.html
+++ b/templates/indicators/indicator_form_helper.html
@@ -550,14 +550,12 @@
     function toggleCummulativeOptions(unit_of_measure_type) {
         // the top option is always the default option
         if (unit_of_measure_type == 2) {
-            $("#id_span_is_cumulative_header h4").text("{% trans 'PERCENTAGE (%) INDICATORS' %}");
             show_hide_cummulative_inputs('percent')
             $("#id_is_cumulative_1").prop("checked", false);
             // Although it's not displayed, when the measurement type is cumulative, the input should be set to true
             // so the is_cumulative input can be submitted with the correct value
             $("#id_is_cumulative_2").prop("checked", true);
         } else {
-            $("#id_span_is_cumulative_header h4").text("{% trans 'OPTIONS FOR NUMBER (#) INDICATORS' %}");
             show_hide_cummulative_inputs('number')
             $("#id_is_cumulative_1").prop("checked", true);
             $("#id_is_cumulative_2").prop("checked", false);
@@ -567,6 +565,7 @@
     function show_hide_cummulative_inputs(type) {
         //d-flex overrides display settings, so we need to apply and unapply depending on visibility
         if (type == 'number') {
+            $("#id_span_is_cumulative_header").text("{% trans 'OPTIONS FOR NUMBER (#) INDICATORS' %}");
             $("#id_div_is_cumulative_section1").show();
             $("#id_div_is_cumulative_section1").addClass("d-flex");
             $("#id_div_is_cumulative_section2").show();
@@ -575,6 +574,7 @@
             $("#id_div_is_cumulative_section3").removeClass("d-flex");
         }
         else {
+            $("#id_span_is_cumulative_header").text("{% trans 'PERCENTAGE (%) INDICATORS' %}");
             $("#id_div_is_cumulative_section3").show();
             $("#id_div_is_cumulative_section3").addClass("d-flex");
             $("#id_div_is_cumulative_section1").hide();

--- a/templates/indicators/indicatortargets.html
+++ b/templates/indicators/indicatortargets.html
@@ -59,7 +59,7 @@
                             <td align="left" class="align-middle">
                                 <strong>
                                     <span id="id_span_label_targets_sum">
-                                        {% if indicator.unit_of_measure_type == 1%}{% trans "Sum" %}{% else %}{% trans "Average" %}{% endif %} {% trans "of targets" %}
+                                        {% trans "Sum of targets" %}
                                     </span>
                                 </strong>
                             </td>
@@ -121,13 +121,11 @@
                     {% with unit_type=indicator.unit_of_measure_type %}
                         <div id="id_is_cumulative_section_header" class="d-flex flex-row px-2 pt-2 mb-1">
                             <strong>
-                                <span id="id_span_is_cumulative_header">
-                                    {% if unit_type == 1 %}
-                                        <h4>{% trans "OPTIONS FOR NUMBER (#) INDICATORS" %}</h4>
-                                    {% else %}
-                                        <h4>{% trans "PERCENTAGE (%) INDICATORS" %}</h4>
-                                    {% endif %}
-                                </span>
+                                <h4>
+                                    <span id="id_span_is_cumulative_header">
+                                        {% trans "OPTIONS FOR NUMBER (#) INDICATORS" %}
+                                    </span>
+                                </h4>
                             </strong>
                         </div>
                         <div id="id_div_is_cumulative_section1" class="flex-row px-2 pb-2">


### PR DESCRIPTION
Fix bug in UOM type options.  Missing UOM and is_cumulative values in the database were being treated as percents.  Now they're being treated as numbers, which is the visual default as well. 