### PR TITLE
Remove duplicate, unused import

### DIFF
--- a/indicators/views/views_reports.py
+++ b/indicators/views/views_reports.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from dateutil import rrule, parser
 from dateutil.relativedelta import relativedelta
 from datetime import datetime
-import datetime as dt
 from django.core.urlresolvers import reverse_lazy
 from django.db.models import Sum, Avg, Subquery, OuterRef, Case, When, Q, F, Min, Max
 from django.views.generic import TemplateView, FormView


### PR DESCRIPTION
Noticed that the datetime module is imported twice. The second import is unused (no methods called on it), so remove it.