### PR TITLE
Changes how indicators are listed, per #350.

### DIFF
--- a/templates/indicators/indicator_list.html
+++ b/templates/indicators/indicator_list.html
@@ -11,12 +11,30 @@
         <div class='card'>
             <div class='card-header d-flex justify-content-between align-items-center'>
                 <span class="program-name fontsize-130">{{ program.name|truncatechars:140 }}</span>
-                <span>
-                    <a href="{% url 'indicator_create' program.id %}" role="button" class="fontsize-130 btn btn-link btn-white"><i class="fas fa-plus-circle"></i> {% trans "Add indicator" %}</a>
-                </span>
+                {% if program.reporting_period_start and program.reporting_period_end %}
+                    <span>
+                        <a href="{% url 'indicator_create' program.id %}" role="button" class="fontsize-130 btn btn-link btn-white"><i class="fas fa-plus-circle"></i> {% trans "Add indicator" %}</a>
+                    </span>
+                {% endif %}
             </div>
             <div class='card-body d-flex justify-content-between align-items-center'>
-                {% if not program.indicator_set.all %}
+                {% if not program.reporting_period_start or not program.reporting_period_end %}
+                    <div class="card-title paddingleft-125 m-0 fontsize-130">
+                        {% trans "Before adding indicators and performance results, we need to know your program's " %}
+                        <a
+                            class="pl-1"
+                            href="#"
+                            data-toggle="modal"
+                            data-program="{{ program.id }}"
+                            data-progstart="{{ program.start_date }}"
+                            data-progend="{{ program.end_date }}"
+                            data-rptstart="{{ program.reporting_period_start }}"
+                            data-rptend="{{ program.reporting_period_end }}"
+                            data-target="#id_reporting_period_modal">
+                                {% trans "reportng start and end dates." %}
+                        </a>
+                    </div>
+                {% elif not program.indicator_set.all %}
                     <div class="card-title paddingleft-125 m-0 fontsize-130">{% trans "No Indicators have been entered for this program" %}</div>
                 {% else %}
                     <a
@@ -36,26 +54,28 @@
                             {% endif %}
                     </a>
                 {% endif %}
-                <span class="d-flex align-items-center">
-                    <strong>
-                        <a class="pr-1" href="{% url 'programIndicatorReport' program.id %}">{% trans 'Indicator plan' %}</a>
-                    </strong>
-                    |
-                    <strong>
-                        <a
-                            class="pl-1"
-                            href="#"
-                            data-toggle="modal"
-                            data-program="{{ program.id }}"
-                            data-progstart="{{ program.start_date }}"
-                            data-progend="{{ program.end_date }}"
-                            data-rptstart="{{ program.reporting_period_start }}"
-                            data-rptend="{{ program.reporting_period_end }}"
-                            data-target="#id_reporting_period_modal">
-                                {% trans 'Reporting period' %}
-                        </a>
-                    </strong>
-                </span>
+                {% if program.reporting_period_start and program.reporting_period_end %}
+                    <span class="d-flex align-items-center">
+                        <strong>
+                            <a class="pr-1" href="{% url 'programIndicatorReport' program.id %}">{% trans 'Indicator plan' %}</a>
+                        </strong>
+                        |
+                        <strong>
+                            <a
+                                class="pl-1"
+                                href="#"
+                                data-toggle="modal"
+                                data-program="{{ program.id }}"
+                                data-progstart="{{ program.start_date }}"
+                                data-progend="{{ program.end_date }}"
+                                data-rptstart="{{ program.reporting_period_start }}"
+                                data-rptend="{{ program.reporting_period_end }}"
+                                data-target="#id_reporting_period_modal">
+                                    {% trans 'Reporting period' %}
+                            </a>
+                        </strong>
+                    </span>
+                {% endif %}
             </div>
             {% if program.indicator_set.all %}
                 <div id="hidden-{{ program.id }}" class="collapse">

--- a/templates/indicators/indicator_reportingperiod_modal.html
+++ b/templates/indicators/indicator_reportingperiod_modal.html
@@ -257,6 +257,7 @@
             }
             if ((testDate = new Date($(event.relatedTarget).data('rptstart'))) == "Invalid Date"){
                 $("#id_reporting_start_date").val("");
+                origRptStart = "";
             }
             else {
                 $("#id_reporting_start_date").val(formatDate(testDate));
@@ -264,6 +265,7 @@
             }
             if ((testDate = new Date($(event.relatedTarget).data('rptend'))) == "Invalid Date"){
                 $("#id_reporting_end_date").val("");
+                origRptStart = "";
             }
             else {
                 $("#id_reporting_end_date").val(formatDate(testDate));
@@ -284,34 +286,62 @@
         $("#id_gait_start_date, #id_gait_end_date, #id_reporting_start_date, #id_reporting_end_date")
             .removeClass("color-red");
         $("#id_reporting_start_date, #id_reporting_end_date, #submit-id-submit").attr("disabled", false);
+
+        // Reload the page if the the original reporting dates were blank and they now have values.  Need to do
+        // this so the add button and reporting and indicator links appear with the program on the indicator list.
+        // Only need to check one because the form can only be saved if both have a value.
+        if (origRptEnd == "" && $("#id_reporting_end_date").val() != "") {
+            window.location.reload(true);
+        }
+
     });
+
 
     $("#reportingperiod_update_form").on('submit', function(e) {
         e.preventDefault();
-        $.post($(this).attr('action'), $(this).serialize(), function(data){
-            var program_id = data.program_id;
-            var modalLink = $(`a[data-program="${program_id}"]`);
-            modalLink.data("rptstart", data.rptstart);
-            modalLink.data("rptend", data.rptend);
-            createAlert(
-              "success",
-              "{% trans 'Success. Reporting period changes were saved.' %}",
-              true,
-              "#div-id-reportingperiod-alert");
+        if ($("#id_reporting_start_date").val() == "" || $("#id_reporting_end_date").val() == ""){
+          createAlert(
+            "danger",
+            "{% trans 'You must enter values for the reporting start and end dates before saving.' %}",
+            false,
+            "#div-id-reportingperiod-alert");
+        }
+        else{
+            $.post($(this).attr('action'), $(this).serialize(), function(data){
+                var program_id = data.program_id;
+                var modalLink = $(`a[data-program="${program_id}"]`);
+                modalLink.data("rptstart", data.rptstart);
+                modalLink.data("rptend", data.rptend);
+                createAlert(
+                  "success",
+                  "{% trans 'Success. Reporting period changes were saved.' %}",
+                  true,
+                  "#div-id-reportingperiod-alert");
 
-        }).fail(function(data) {
-            createAlert(
-              "danger",
-              "{% trans 'There was a problem saving your changes.' %}",
-              false,
-              "#div-id-reportingperiod-alert")
-        });
+            }).fail(function(data) {
+                createAlert(
+                  "danger",
+                  "{% trans 'There was a problem saving your changes.' %}",
+                  false,
+                  "#div-id-reportingperiod-alert");
+            });
+        }
     });
 
     $("#reportingperiod_update_form").on('reset', function(e) {
         e.preventDefault();
-        $("#id_reporting_start_date").val(formatDate(new Date(origRptStart)));
-        $("#id_reporting_end_date").val(formatDate(new Date(origRptEnd)));
+        if (origRptStart == "") {
+            $("#id_reporting_start_date").val("");
+        }
+        else {
+            $("#id_reporting_start_date").val(formatDate(new Date(origRptStart)));
+        }
+        if (origRptEnd == "") {
+            $("#id_reporting_end_date").val("");
+        }
+        else{
+            $("#id_reporting_end_date").val(formatDate(new Date(origRptEnd)));
+        }
 
     });
 


### PR DESCRIPTION
Also contains changes related to #258:
- Reporting period modal will not save if either reporting periods are blank.
- Empty original values are restored when reset is clicked.