### PR TITLE
Simplify & clean up page titles

### DIFF
--- a/reports/templates/report.html
+++ b/reports/templates/report.html
@@ -1,6 +1,9 @@
 {% extends 'base.html' %}
 {% load staticfiles %}
+{% load i18n %}
 {% load crispy_forms_tags %}
+
+{% block title %}{% trans "Program filter reports" %} | {% endblock %}
 
 {% block content %}
     <h3 id="report_type"></h3>
@@ -419,7 +422,7 @@
         </div>
         <div class="col-sm-9">
             <div id='welcome-panel' class="panel panel-success">
-                <div class="panel-heading"> Program Filter Reports</div>
+                <div class="panel-heading"><h1 class="page-title">{% trans "Program filter reports" %}</h1></div>
                 <div class="panel-body" id="welcome" style="padding:5px;"> Filter your search in the panel on the left to see results.</div>
             </div>
             <div id='data-panel' class="panel panel-primary" style="display: none;">

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
         <meta name="description" content="TolaData - TolaActivity: Putting Adaptive Management into Practice">
         <meta name="author" content="TolaData">
 
-        <title>{% block title %} TolaActivity {% endblock %}</title>
+        <title>{% block title %}{% endblock %}TolaActivity</title>
 
         <link rel="icon" href="{% static 'img/favicon.ico' %}">
 

--- a/templates/customdashboard/program_list.html
+++ b/templates/customdashboard/program_list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 
+{% block title %}{% trans "Public dashboards" %} | {% endblock %}
 {% block page_title %}{% trans "Public dashboards" %}{% endblock %}
 
 {% block content %}

--- a/templates/customdashboard/program_list.html
+++ b/templates/customdashboard/program_list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block page_title %}Public Dashboards{% endblock %}
+{% block page_title %}{% trans "Public dashboards" %}{% endblock %}
 
 {% block content %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
-
-{% block content %}
 {% load i18n %}
+
+{% block title %}{% trans "Dashboard" %} | {% endblock %}
+{% block page_title %}{% trans "Dashboard" %}{% endblock %}
+{% block content %}
 
 <script src="{{ STATIC_URL }}js/highcharts/js/highcharts.js"></script>
 <script src="{{ STATIC_URL }}js/highcharts/js/modules/exporting.js"></script>
@@ -281,7 +283,6 @@ $(function () {
         <div class="panel-heading">
             <div class="row">
                 <div class="col-md-4">
-                    <h4>{% trans "Tola-Activity Dashboard" %}</h4>
                 </div>
 
                 <div class="col-md-6 col-md-offset-2">

--- a/templates/indicators/collecteddata_list.html
+++ b/templates/indicators/collecteddata_list.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
+
+{% block title %}{% trans "Collected indicator data" %} | {% endblock %}
+{% block page_title %}{% trans "Collected indicator data" %}{% endblock %}
+
 {% block bread_crumb %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
@@ -14,7 +18,6 @@
 
 
 
-{% block page_title %}{% trans "Collected Indicator Data" %}{% endblock %}
 
 {% block content %}
 

--- a/templates/indicators/data_report.html
+++ b/templates/indicators/data_report.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
+
+{% block title %}{% trans "Indicator report" %} | {% endblock %}
+{% block page_title %}{% trans "Indicator report" %}{% endblock %}
+
 {% block bread_crumb %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
@@ -21,7 +25,6 @@
 
 {% endblock bread_crumb %}
 
-{% block page_title %}{% trans "Indicator Report" %}{% endblock %}
 
 {% block content %}
 

--- a/templates/indicators/disaggregation_report.html
+++ b/templates/indicators/disaggregation_report.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
 
+{% block title %} {% trans "Indicator disaggregation report" %} | {% endblock %}
+{% block page_title %} {% trans "Indicator disaggregation report" %} {% endblock %}
+
 {% block bread_crumb %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
@@ -10,7 +13,6 @@
 </nav>
 {% endblock %}
 
-{% block page_title %} {% trans "Indicator Disaggregation Report" %} {% endblock %}
 
 {% block content %}
     {% include "indicators/filter.html"%}
@@ -20,13 +22,13 @@
         <table id="disrep_table"
                 class="table table-bordered"
                 cellspacing="0"
-                width:100%"
+                width="100%"
                 role="grid"
                 aria-describedby="Indicator_Disaggregation">
             <thead>
                 <tr>
-                    <th role="row" class="noExport" style="display:none;" rowspan="2">{% trans "PID</th>
-                    <th role="row" class="noExport" style="display:none;" rowspan="2">{% trans "IndicatorID</th>
+                    <th role="row" class="noExport" style="display:none;" rowspan="2">{% trans "PID" %}</th>
+                    <th role="row" class="noExport" style="display:none;" rowspan="2">{% trans "IndicatorID" %}</th>
                     <th role="row" rowspan="2">{% trans "Number" %}</th>
                     <th role="row" rowspan="2">{% trans "Indicator" %}</th>
                     <th role="row" rowspan="2">{% trans "LOP Target" %}</th>

--- a/templates/indicators/indicator_form.html
+++ b/templates/indicators/indicator_form.html
@@ -1,9 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block page_title %}
-  {% trans "Indicator setup" %}
-{% endblock %}
+{% block title %}{% trans "Indicator setup" %} | {% endblock %}
+{% block page_title %}{% trans "Indicator setup" %}{% endblock %}
 
 {% block content %}
     <div id="numDataPoints" style="display: none;">{{ object.collecteddata_set.all.count }}</div>

--- a/templates/indicators/indicator_list.html
+++ b/templates/indicators/indicator_list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% block page_title %}{% trans "Program Indicators" %}{% endblock %}
+{% block title %}{% trans "Program indicators" %} | {% endblock %}
+{% block page_title %}{% trans "Program indicators" %}{% endblock %}
 
 {% block content %}
 

--- a/templates/indicators/iptt_quickstart.html
+++ b/templates/indicators/iptt_quickstart.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% load widget_tweaks %}
 {% load i18n %}
-{% block page_title %}{% trans "Indicator Performance Tracking Table" %}{% endblock %}
-{% block title %}{% trans "Indicator Performance Tracking Table" %}{% endblock %}
+{% block title %}{% trans "Indicator performance tracking table" %} | {% endblock %}
+{% block page_title %}{% trans "Indicator performance tracking table" %}{% endblock %}
 
 {% block content %}
     <div id="id_div_top_quickstart_iptt" >

--- a/templates/indicators/report.html
+++ b/templates/indicators/report.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
+
+{% block title %}{% trans "Indicator report" %} | {% endblock %}
+{% block page_title %}{% trans "Indicator report" %}{% endblock %}
+
 {% block bread_crumb %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
@@ -12,7 +16,6 @@
 {% endblock bread_crumb %}
 {% load render_table from django_tables2 %}
 
-{% block page_title %}{% trans "Indicator Report" %}{% endblock %}
 
 {% block content %}
     {% include "indicators/filter.html"%}

--- a/templates/indicators/tva_report.html
+++ b/templates/indicators/tva_report.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
 
+{% block title %}{% trans "Indicator targets vs actuals report" %} | {% endblock %}
+{% block page_title %}{% trans "Indicator targets vs actuals report" %}{% endblock %}
+
 {% block bread_crumb %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
@@ -12,7 +15,6 @@
 </nav>
 {% endblock %}
 
-{% block page_title %}{% trans "Indicator Targets vs Actuals Report" %}{% endblock %}
 
 {% block content %}
     {% include "indicators/filter.html"%}

--- a/templates/registration/profile.html
+++ b/templates/registration/profile.html
@@ -1,11 +1,12 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Account Profile{% endblock %}
+{% block title %}{% trans 'Profile' %}{% endblock %}
 
 
 {% block content %}
 
-	<h3>User Registration/Profile</h3>
+<h3>{% trans 'Profile' %}</h3>
     {% if form.errors %}
         {% for field in form %}
             {% for error in field.errors %}

--- a/templates/workflow/documentation_form.html
+++ b/templates/workflow/documentation_form.html
@@ -1,15 +1,17 @@
 {% extends "base.html" %}
 {% load widget_tweaks %}
 {% load i18n %}
-<div>
+
+{% block title %}{% trans "Document" %} | {% endblock %}
+{% block page_title %}{% trans "Document" %}{% endblock %}
+
+{% block bread_crumb %}
 <ol class="breadcrumb">
   <li><a href="/workflow/dashboard/0/">{% trans 'Projects' %}</a></li>
   <li><a href="/workflow/documentation_list/{{ getProgram.id }}">Documentations</a></li>
   <li class="active">Document</li>
 </ol>
-</div>
-{% block page_title %}{% trans 'Document' %}{% endblock %}
-{% block title %}{% trans 'Document'%}{% endblock %}
+{% endblock %}
 
 {% block content %}
     <script>

--- a/templates/workflow/documentation_form.html
+++ b/templates/workflow/documentation_form.html
@@ -8,8 +8,8 @@
   <li class="active">Document</li>
 </ol>
 </div>
-{% block page_title %}Document Form{% endblock %}
-{% block title %} Document Form {% endblock %}
+{% block page_title %}{% trans 'Document' %}{% endblock %}
+{% block title %}{% trans 'Document'%}{% endblock %}
 
 {% block content %}
     <script>

--- a/templates/workflow/documentation_list.html
+++ b/templates/workflow/documentation_list.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% block title %}{% trans "Documents" %} | {% endblock %}
+{% block page_title %}{% trans "Documents" %}{% endblock %}
 {% block bread_crumb %}
-{% load i18n %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="/workflow/dashboard/0/">{% trans 'Projects' %}</a></li>
@@ -14,7 +15,7 @@
     </ol>
 </nav>
 {% endblock %}
-{% block page_title %}{% trans 'Documents' %}{% endblock %}
+
 
 {% block content %}
 

--- a/templates/workflow/documentation_list.html
+++ b/templates/workflow/documentation_list.html
@@ -14,7 +14,7 @@
     </ol>
 </nav>
 {% endblock %}
-{% block page_title %}Document List{% endblock %}
+{% block page_title %}{% trans 'Documents' %}{% endblock %}
 
 {% block content %}
 

--- a/templates/workflow/programdashboard_list.html
+++ b/templates/workflow/programdashboard_list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load mathfilters %}
+{% block title %}{% trans 'Projects' %} | {% endblock %}
 {% block page_title %}{% trans 'Projects' %}{% endblock %}
 
 {% block content %}

--- a/templates/workflow/projectagreement_form.html
+++ b/templates/workflow/projectagreement_form.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% block title %}{% trans "Project initiation form" %} | {% endblock %}
+{% block page_title %}{% trans "Project initiation form" %}{% endblock %}
 {% block bread_crumb %}
 <ol class="breadcrumb">
   <li><a href="/workflow/dashboard/0/">{% trans 'Projects' %}</a></li>
@@ -38,7 +40,6 @@
 
 {% endblock %}
 
-{% block page_title %}Project Initiation Form{% endblock %}
 {% block content %}
     {% if p_agreement%}
         <h4>{{p_agreement|truncatechars:150}}</h4>

--- a/templates/workflow/projectcomplete_form.html
+++ b/templates/workflow/projectcomplete_form.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% block title %}{% trans "Project tracking form" %} | {% endblock %}
+{% block page_title %}{% trans "Project tracking form" %}{% endblock %}
 {% block bread_crumb %}
 <ol class="breadcrumb">
   <li><a href="/workflow/dashboard/0/">{% trans 'Projects' %}</a></li>
@@ -7,7 +9,6 @@
   <li class="active">Project Tracking Form </li>
 </ol>
 {%  endblock %}
-{% block page_title %}Project Tracking Form{% endblock %}
 
 {% block extra_js_in_body %}
     <script type="text/javascript" src="{{ STATIC_URL }}js/select2.min.js"></script>

--- a/templates/workflow/report.html
+++ b/templates/workflow/report.html
@@ -1,6 +1,11 @@
 {% extends "base.html" %}
+{% load crispy_forms_tags %}
+{% load i18n %}
+{% block title %}{% trans "Project report" %} | {% endblock %}
+{% block page_title %}{% trans "Project report" %}{% endblock %}
+
 {% block bread_crumb %}
-<nav class="breadcrumb">
+<nav class="">
     <ol class="breadcrumb">
         <li class="breadcrumb-item">
             <a href="/workflow/dashboard/0/">Program Dashboards</a>
@@ -10,11 +15,9 @@
 </nav>
 {% endblock bread_crumb %}
 
-{% block page_title %}Project Report{% endblock %}
 
 {% block content %}
 
-{% load crispy_forms_tags %}
 {% crispy form form.helper %}
 <script type="text/javascript">
     var table;

--- a/templates/workflow/site_profile_list.html
+++ b/templates/workflow/site_profile_list.html
@@ -18,7 +18,7 @@
 
 {% endblock %}
 
-{% block page_title %}Site Profile List{% endblock %}
+{% block page_title %}{% trans 'Sites' %}{% endblock %}
 
 {% block content %}
 

--- a/templates/workflow/site_profile_list.html
+++ b/templates/workflow/site_profile_list.html
@@ -83,10 +83,10 @@
  <!-- Display site profiles & projects -->
 <table class="table table-sm table-hover table-striped">
     <tr>
-        <th>Date Created</th>
-        <th>Profile Name</th>
+        <th>Date created</th>
+        <th>Site name</th>
         <th>Status</th>
-        <th>Profile Type</th>
+        <th>Site type</th>
         <th>Province</th>
         <th>District</th>
         <th style="width:110px;">&nbsp;</th>

--- a/templates/workflow/site_profile_list.html
+++ b/templates/workflow/site_profile_list.html
@@ -1,8 +1,9 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load group_tag %}
+{% block title %}{% trans "Sites" %} | {% endblock %}
+{% block page_title %}{% trans "Sites" %}{% endblock %}
 {% block bread_crumb %}
-{% load i18n %}
 
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
@@ -18,7 +19,6 @@
 
 {% endblock %}
 
-{% block page_title %}{% trans 'Sites' %}{% endblock %}
 
 {% block content %}
 

--- a/templates/workflow/siteprofile_form.html
+++ b/templates/workflow/siteprofile_form.html
@@ -13,7 +13,7 @@
 </ol>
 </div>
 {% endblock %}
-{% block page_title %}Site Profile Form{% endblock %}
+{% block page_title %}{% trans 'Site' %}{% endblock %}
 
 {% block content %}
     {% include "form_guidance.html" %}

--- a/templates/workflow/siteprofile_form.html
+++ b/templates/workflow/siteprofile_form.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% block title %}{% trans "Site" %} | {% endblock %}
+{% block page_title %}{% trans "Site" %}{% endblock %}
 {% block bread_crumb %}
 <div>
 <ol class="breadcrumb">
@@ -13,7 +15,6 @@
 </ol>
 </div>
 {% endblock %}
-{% block page_title %}{% trans 'Site' %}{% endblock %}
 
 {% block content %}
     {% include "form_guidance.html" %}

--- a/templates/workflow/stakeholder_form.html
+++ b/templates/workflow/stakeholder_form.html
@@ -14,7 +14,7 @@
 </nav>
 
 {% endblock %}
-{% block page_title %}Stakeholder Form{% endblock %}
+{% block page_title %}{% trans 'Stakeholder' %}{% endblock %}
 
 {% block content %}
     <script type="text/javascript" src="{{ STATIC_URL }}js/select2.min.js"></script>

--- a/templates/workflow/stakeholder_form.html
+++ b/templates/workflow/stakeholder_form.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% block title %}{% trans 'Stakeholder' %} | {% endblock %}
+{% block page_title %}{% trans 'Stakeholder' %}{% endblock %}
 {% block bread_crumb %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
@@ -14,7 +16,6 @@
 </nav>
 
 {% endblock %}
-{% block page_title %}{% trans 'Stakeholder' %}{% endblock %}
 
 {% block content %}
     <script type="text/javascript" src="{{ STATIC_URL }}js/select2.min.js"></script>

--- a/templates/workflow/stakeholder_list.html
+++ b/templates/workflow/stakeholder_list.html
@@ -10,7 +10,7 @@
     </ol>
 </nav>
 {% endblock %}
-{% block page_title %}Stakeholder List{% endblock %}
+{% block page_title %}{% trans 'Stakeholders' %}{% endblock %}
 
 {% block content %}
 <div class="btn-group" role="group">

--- a/templates/workflow/stakeholder_list.html
+++ b/templates/workflow/stakeholder_list.html
@@ -35,8 +35,6 @@
 <a href="/workflow/stakeholder_add/0/" class="btn btn-link btn-add"><i class="fas fa-plus-circle"></i> Add stakeholder</a>
 <br/>
 
-<h3>Stakeholder</h3>
-
 <a href="/workflow/export_stakeholders_list/{{ program_id }}/" class="btn btn-sm btn-primary float-right"><span class="glyphicon glyphicon-export"></span> Export to Excel</a>&nbsp;
 <br><br>
 
@@ -77,17 +75,17 @@
                 retrieve: true,
                 data: stakeholder_records,
                 columns: [
-                    { title: "Date Created", data: "create_date",
+                    { title: "Date created", data: "create_date",
                         "mRender": function (data, sector, row) {
                                 return '<a class="collecteddata" name=' + row.id + ' href="/workflow/stakeholder_update/' + row.id + '/">' + formatDate(row.create_date) + '</a>';
                             },
                         "defaultContent": "<i>Not set</i>"},
-                    { title: "Stakeholder Name", data: "name",
+                    { title: "Stakeholder name", data: "name",
                         "mRender": function (data, name, row) {
                                 return '<a class="collecteddata" name=' + row.id + ' href="/workflow/stakeholder_update/' + row.id + '/">' + row.name + '</a>';
                             },
                         "defaultContent": "<i>Not set</i>"},
-                    { title: "Stakeholder Type", data: "type__name",
+                    { title: "Stakeholder type", data: "type__name",
                         "mRender": function (data, type, row) {
                                 return '<a class="collecteddata" name=' + row.id + ' href="/workflow/stakeholder_update/' + row.id + '/">' + row.type__name + '</a>';
                             },

--- a/templates/workflow/stakeholder_list.html
+++ b/templates/workflow/stakeholder_list.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% block title %}{% trans "Stakeholders" %} | {% endblock %}
+{% block page_title %}{% trans "Stakeholders" %}{% endblock %}
 {% block bread_crumb %}
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
@@ -10,7 +12,6 @@
     </ol>
 </nav>
 {% endblock %}
-{% block page_title %}{% trans 'Stakeholders' %}{% endblock %}
 
 {% block content %}
 <div class="btn-group" role="group">


### PR DESCRIPTION
This addresses #362. I also added the page title to the <title> tag along with a pipe character, viz `Documents | TolaActivity`