### PR TITLE
Fixes #372 and #386

### DIFF
--- a/templates/indicators/indicator_form_common_js.html
+++ b/templates/indicators/indicator_form_common_js.html
@@ -180,6 +180,7 @@
                                 value="${parseFloat(pt.target).toFixed(2).replace(/[.,]00$/, "")}"
                                 data-start-date="${formatDate(pt.start_date)}"
                                 data-end-date="${formatDate(pt.end_date)}"
+                                data-periodictarget="pt"
                                 name="${pt.period}"
                                 placeholder="{% trans 'Enter target' %}"
                                 class="form-control input-value">

--- a/templates/indicators/indicator_form_common_js.html
+++ b/templates/indicators/indicator_form_common_js.html
@@ -173,7 +173,17 @@
                     </td>
 
                     <td class="align-middle" align="right" width="150px">
-                        <input type="number" id="pt-${pt.id}" value="${parseFloat(pt.target).toFixed(2).replace(/[.,]00$/, "")}" data-start-date="${formatDate(pt.start_date)}" data-end-date="${formatDate(pt.end_date)}" name="${pt.period}" placeholder="{% trans 'Enter target' %}" class="form-control input-value">
+                        <span class=${ $("#id_unit_of_measure_type_1").is(":checked")?"input-symbol-percent":""}>
+                            <input
+                                type="number"
+                                id="pt-${pt.id}"
+                                value="${parseFloat(pt.target).toFixed(2).replace(/[.,]00$/, "")}"
+                                data-start-date="${formatDate(pt.start_date)}"
+                                data-end-date="${formatDate(pt.end_date)}"
+                                name="${pt.period}"
+                                placeholder="{% trans 'Enter target' %}"
+                                class="form-control input-value">
+                        </span>
                             <span id="hint_id_pt_${pt.period}" style="margin:0px;" class="help-block"> </span>
                     </td>
                 </tr>
@@ -223,10 +233,6 @@
             var isLastIteration = true;
             var target_frequency = $("#id_target_frequency").val();
             var markup = createPeriodicTargetRow(pt, target_frequency, isLastIteration);
-            // if target_frequency is not "EVENT" then hide the delete button
-            if (target_frequency != 8) {
-                $("#periodic_targets_table tbody tr:nth-last-child(3)").find("a").hide();
-            }
             $("#periodic_targets_table tbody tr:nth-last-child(2)").before(markup);
         });
 


### PR DESCRIPTION
Fixes #372, % signs for new events are now reset when the UOM type is changed.  Also fixes #386. Summing of new event values is now handled correctly.

Not obvious from the diff, added this property to the input: data-periodictarget="pt".