### PR TITLE
Related to #491, eliminate STATIC_DIRS since we're not using the /sta…

### DIFF
--- a/tola/settings/base.py
+++ b/tola/settings/base.py
@@ -113,9 +113,7 @@ STATIC_URL = '/static/'
 
 
 # See: https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#std:setting-STATICFILES_DIRS
-STATICFILES_DIRS = (
-    normpath(join(SITE_ROOT, 'static')),
-)
+STATICFILES_DIRS = ()
 
 # See: https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#staticfiles-finders
 STATICFILES_FINDERS = (
@@ -400,5 +398,3 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
 GOOGLE_ANALYTICS_PROPERTY_ID = None # replaced in private settings file
 GOOGLE_ANALYTICS_DOMAIN = 'example.org' # replaced in private settings file
-
-


### PR DESCRIPTION
…tic dir any more and its absence causes collectstatic to fail.