### PR TITLE
Remove debug print

### DIFF
--- a/indicators/tests/test_reports.py
+++ b/indicators/tests/test_reports.py
@@ -7,6 +7,7 @@ from django.test import Client, RequestFactory, TestCase
 from factories.workflow_models import ProgramFactory, UserFactory
 from indicators.models import Indicator
 from indicators.views.views_reports import IPTTReportQuickstartView, IPTT_Mixin
+from indicators.forms import IPTTReportQuickstartForm
 from workflow.models import Program
 
 
@@ -234,18 +235,23 @@ class IPTTReportQuickstartViewTestCase(TestCase):
         """Do we get the correct form kwargs?"""
         pass
 
-    @skip('WIP: Currently fails')
+    #@skip('WIP: Currently fails')
+    # TODO: This fails because the form is not valid; unclear to me what
+    # TODO: invalidates the form; see indicators/views/views_reports.py:1088-1091
     def test_post_with_valid_form(self):
         """Does POSTing to iptt_quickstart with valid form data return 302
         and redirect to /indicators/iptt_report/{program_id}/{reporttype}/"""
         p = ProgramFactory()
-        data = {'csrfmiddlewaretoken': 'lolwut?',
+        data = {'csrfmiddlewaretoken': 'lolwut',
                 'program': p.id,
                 'formprefix': 'targetperiods',
+                'timeframe': 1,
                 'targetperiods': 1,
-                'timeframe': 1, }
+                'numrecentperiods': None,
+                'prefix': 'targetperiods', }
         path = reverse_lazy('iptt_quickstart')
-        response = self.client.post(path, data=data, follow=True)
+
+        response = self.client.post(path, data=data, kwargs=data, follow=True)
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(len(response.redirect_chain), 1)

--- a/indicators/tests/test_reports.py
+++ b/indicators/tests/test_reports.py
@@ -235,7 +235,7 @@ class IPTTReportQuickstartViewTestCase(TestCase):
         """Do we get the correct form kwargs?"""
         pass
 
-    #@skip('WIP: Currently fails')
+    @skip('WIP: Currently fails')
     # TODO: This fails because the form is not valid; unclear to me what
     # TODO: invalidates the form; see indicators/views/views_reports.py:1088-1091
     def test_post_with_valid_form(self):

--- a/indicators/views/views_indicators.py
+++ b/indicators/views/views_indicators.py
@@ -514,7 +514,6 @@ class IndicatorUpdate(UpdateView):
 
     def form_invalid(self, form):
         messages.error(self.request, _('Invalid Form'), fail_silently=False)
-        print("...............%s.........................." % form.errors)
         return self.render_to_response(self.get_context_data(form=form))
 
     def form_valid(self, form, **kwargs):


### PR DESCRIPTION
A stray debug print might have been blowing up my unit test. In any event it was ugly and did not belong there. Killed it with :fire: 