### PR TITLE
Re #543, add Scenario class to test framework, add test for scope

### DIFF
--- a/indicators/models.py
+++ b/indicators/models.py
@@ -313,6 +313,9 @@ class Indicator(models.Model):
         (DIRECTION_OF_CHANGE_NEGATIVE, _("Decrease (-)"))
     )
 
+    ONSCOPE_MARGIN = .15
+
+
     indicator_key = models.UUIDField(
         default=uuid.uuid4, unique=True, help_text=" "),
 

--- a/indicators/tests/test_indicator_list_view.py
+++ b/indicators/tests/test_indicator_list_view.py
@@ -7,7 +7,7 @@ from factories.indicators_models import IndicatorTypeFactory
 from factories.workflow_models import ProgramFactory
 from workflow.models import Country, Program
 from indicators.models import Indicator
-from tola.test.base_classes import TestBase, ScenarioBase
+from tola.test.base_classes import TestBase, ScenarioBase, ScenarioBase2, IndicatorDetailsMixin, IndicatorStatsMixin
 from tola.test.scenario_definitions import indicator_scenarios
 from tola.test.utils import instantiate_scenario, generate_core_indicator_data
 
@@ -98,16 +98,21 @@ class CollectedDataTest(TestBase, TestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class DefaultScenarioTest(ScenarioBase, TestCase):
+class DefaultScenarioTest(ScenarioBase, IndicatorDetailsMixin, TestCase):
     scenario = indicator_scenarios['scenario_1i-default_5pt_3cd']
     url_name = 'collected_data_view'
 
 
-class CumulativeNumberScenarioTest(ScenarioBase, TestCase):
+class CumulativeNumberScenarioTest(ScenarioBase, IndicatorDetailsMixin, TestCase):
     scenario = indicator_scenarios['scenario_1i-cumulative_number_5pt_3cd']
     url_name = 'collected_data_view'
 
 
-class PercentScenarioTest(ScenarioBase, TestCase):
+class PercentScenarioTest(ScenarioBase, IndicatorDetailsMixin, TestCase):
     scenario = indicator_scenarios['scenario_1i-cumulative_percent_5pt_3cd']
     url_name = 'collected_data_view'
+
+
+class DefaultScenarioStatsTest(ScenarioBase2, IndicatorStatsMixin, TestCase):
+    scenario = indicator_scenarios['scenario_1i-default_5pt_3cd_7ev']
+    url_name = 'program_page'

--- a/indicators/views/views_indicators.py
+++ b/indicators/views/views_indicators.py
@@ -1457,6 +1457,7 @@ class ProgramPage(ListView):
         type_ids = set(indicators.values_list('indicator_type', flat=True))
         indicator_types = IndicatorType.objects.filter(id__in=list(type_ids))
         indicator_count = indicators.count()
+        scope_percents = {'low': 0, 'on_scope': 0, 'high': 0}
 
         c_data = {
             'program': program,
@@ -1467,6 +1468,7 @@ class ProgramPage(ListView):
             'indicator_filter_name': indicator_filter_name,
             'type_filter_id': type_filter_id,
             'type_filter_name': type_filter_name,
+            'scope_percents': scope_percents,
         }
         return render(request, self.template_name, c_data)
 

--- a/tola/test/base_classes.py
+++ b/tola/test/base_classes.py
@@ -1,4 +1,6 @@
 from unittest import skip
+import datetime
+from decimal import Decimal
 
 from django.test import RequestFactory, Client
 from django.urls import reverse_lazy
@@ -38,7 +40,7 @@ class TestBase(object):
 class ScenarioBase(TestBase):
 
     """
-    Note: many of these test rely on the indicators and periodic targets being created and rendered to the context
+    Note: many of these tests rely on the indicators and periodic targets being created and rendered to the context
     variable in the correct order.  This is a short cut so the exact periods don't need to be calculated.
     It is assumed that the periodic target generation function will be tested elsewhere.
     """
@@ -54,31 +56,72 @@ class ScenarioBase(TestBase):
     def setUp(self):
         super(ScenarioBase, self).setUp()
         self.indicator.delete()
-        indicator_ids = instantiate_scenario(self.program.id, self.scenario)
-        if len(indicator_ids) > 1:
-            raise ImproperlyConfigured('The scenario contained more than one indicator')
-        self.indicators = Indicator.objects.filter(id__in=indicator_ids)
+        self.indicator_ids = instantiate_scenario(self.program.id, self.scenario)
+        self.indicators = Indicator.objects.filter(id__in=self.indicator_ids)
         self.url = reverse_lazy(self.url_name, args=[self.indicators.first().id, self.program.id])
         self.response = self.client.get(self.url)
 
     def test_periodic_targets_have_correct_targets(self):
-        scenario_targets = self.scenario[0].periodic_target_targets
+        scenario_targets = self.scenario.indicators[0].periodic_target_targets
         response_targets = [pt.target for pt in self.response.context['periodictargets']]
         self.assertEqual(scenario_targets, response_targets)
 
     def test_result_set_is_correct(self):
-        scenario_collected_data = self.scenario[0].collected_data_sets
+        scenario_collected_data = self.scenario.indicators[0].collected_data_sets
+        response_collected_data = []
+        for pt in self.response.context['periodictargets']:
+            response_collected_data.append(list(pt.getcollected_data.values_list('achieved', flat=True)))
+        self.assertEqual(scenario_collected_data, response_collected_data)
+
+# TODO: see if there is a way to abstract this better so a new base doesn't need to be created for each URL
+class ScenarioBase2(TestBase):
+
+    """
+    Note: many of these tests rely on the indicators and periodic targets being created and rendered to the context
+    variable in the correct order.  This is a short cut so the exact periods don't need to be calculated.
+    It is assumed that the periodic target generation function will be tested elsewhere.
+    """
+
+    @property
+    def scenario(self):
+        raise ImproperlyConfigured("A value for scenario hasn't been set")
+
+    @property
+    def url_name(self):
+        raise ImproperlyConfigured("A value for the url_name variable hasn't been set")
+
+    def setUp(self):
+        super(ScenarioBase2, self).setUp()
+        self.indicator.delete()
+        self.indicator_ids = instantiate_scenario(self.program.id, self.scenario)
+        self.indicators = Indicator.objects.filter(id__in=self.indicator_ids)
+        self.url = reverse_lazy(self.url_name, args=[self.program.id, 0, 0])
+        self.response = self.client.get(self.url)
+
+
+
+class IndicatorDetailsMixin(TestBase):
+
+    """ Use this mixin to test the correct targets and collected data is returned from a query"""
+
+    def test_periodic_targets_have_correct_targets(self):
+        scenario_targets = self.scenario.indicators[0].periodic_target_targets
+        response_targets = [pt.target for pt in self.response.context['periodictargets']]
+        self.assertEqual(scenario_targets, response_targets)
+
+    def test_result_set_is_correct(self):
+        scenario_collected_data = self.scenario.indicators[0].collected_data_sets
         response_collected_data = []
         for pt in self.response.context['periodictargets']:
             response_collected_data.append(list(pt.getcollected_data.values_list('achieved', flat=True)))
         self.assertEqual(scenario_collected_data, response_collected_data)
 
     def test_each_periodic_target_result_sum_is_correct(self):
-        scenario_sums = self.scenario[0].collected_data_sum_by_periodic_target
+        scenario_sums = self.scenario.indicators[0].collected_data_sum_by_periodic_target
         response_sums = []
         for pt in self.response.context['periodictargets']:
-            if self.scenario[0].unit_of_measure_type == Indicator.NUMBER:
-                if self.scenario[0].is_cumulative:
+            if self.scenario.indicators[0].unit_of_measure_type == Indicator.NUMBER:
+                if self.scenario.indicators[0].is_cumulative:
                     response_sums.append(pt.cumulative_sum)
                 else:
                     response_sums.append(pt.achieved_sum)
@@ -89,11 +132,11 @@ class ScenarioBase(TestBase):
 
     def test_lop_row_target_value_correct(self):
         response_lop_target = self.response.context['indicator'].lop_target
-        self.assertEqual(unicode(self.scenario[0].lop_target), response_lop_target)
+        self.assertEqual(unicode(self.scenario.indicators[0].lop_target), response_lop_target)
 
     def test_lop_row_actual_value_correct(self):
         response_value = self.response.context.pop()['grand_achieved_sum']
-        scenario_value = decimalize(self.scenario[0].collected_data_sum)
+        scenario_value = decimalize(self.scenario.indicators[0].collected_data_sum)
         self.assertEqual(scenario_value, response_value)
 
     @skip('Not implemented yet')
@@ -107,3 +150,32 @@ class ScenarioBase(TestBase):
     @skip('Percent is calced in the template, it should be correct if targets and actuals are correct.')
     def test_lop_row_percent_value_correct(self):
         pass
+
+
+class IndicatorStatsMixin(object):
+
+    """
+    Add this to a class based test if you want to test the indicator statistics
+    """
+
+    @skip('View not implmented yet')
+    def test_indicators_near_target(self):
+        buckets_values = {'low': 0, 'on_scope': 0, 'high': 0}
+        target_date = datetime.date(2018, 9, 5)
+        for i, indicator_id in enumerate(self.indicator_ids):
+            db_indicator = Indicator.objects.get(id=indicator_id)
+            periodic_target_count = len(db_indicator.periodictargets.filter(end_date__lt=target_date))
+            scenario_ratio = self.scenario.indicators[i].program_to_date_achieved_ratio(
+                period_ceiling=periodic_target_count)
+            if scenario_ratio > 1 + Indicator.ONSCOPE_MARGIN:
+                buckets_values['high'] += 1
+            elif scenario_ratio < 1 - Indicator.ONSCOPE_MARGIN:
+                buckets_values['low'] += 1
+            else:
+                buckets_values['on_scope'] += 1
+
+        # TODO: git rid of float in fovor of a Decimal?
+        buckets_percents = {k: float(v)/len(self.indicator_ids) for (k, v) in buckets_values.iteritems()}
+
+        self.assertEqual(buckets_percents, self.response.context['scope_percents'])
+

--- a/tola/test/scenario_definitions.py
+++ b/tola/test/scenario_definitions.py
@@ -1,4 +1,4 @@
-from tola.test.utils import PeriodicTargetValues, IndicatorValues
+from tola.test.utils import PeriodicTargetValues, IndicatorValues, Scenario
 
 from indicators.models import Indicator
 
@@ -6,12 +6,18 @@ indicator_scenarios = {}
 indicator_values = []
 
 """
+DON'T CHANGE THESE SCENARIOS UNLESS YOU'RE SURE YOU KNOW WHAT YOU'RE DOING!!!!
+These are meant to be common scenarios that can be used in many different tests.  If you change a scenario, 
+the change will ripple through all tests that use this scenario, potentially invalidating the tests that are based
+on it and creating a rift in space-time. If your test requires a very specific setup, you might be better off 
+defining it in your test.
+
 Scenario names follow the general pattern of:
-<indicator count>i-<indicator config>_<periodic target count>pt_<collected data count>cd_<evidence count>_ev
+<indicator count>i-<indicator config>_<periodic target count>pt_<collected data count>cd_<evidence count>ev
 
 If you want to associate evidence with a collected data record, you should use the evidence keyword
-to pass in an iterable of the same size as the one you are using for collected_data.  This array should
-contain booleans representing whether a collected data record has documentary evidence or not.
+to pass in an indexable (i.e. list or tuple) of the same size as the one you are using for collected_data.  
+This array should contain booleans representing whether a collected data record has documentary evidence or not.
 """
 
 # Create 2 indicators with default indicator settings.  Create 4 periodic targets per indicator.
@@ -27,7 +33,7 @@ pts = [
     PeriodicTargetValues(target=230, collected_data=(60, 35, 15)),
     PeriodicTargetValues(target=240, collected_data=(60, 35, 15)), ]
 indicator_values.append(IndicatorValues(periodic_targets=pts))
-indicator_scenarios['scenario_2i-default_4pt_3cd'] = indicator_values
+indicator_scenarios['scenario_2i-default_4pt_3cd'] = Scenario(indicators=indicator_values)
 
 # Create 1 indicator with default indicator settings.  Create 5 periodic targets.
 pts = [
@@ -36,9 +42,9 @@ pts = [
     PeriodicTargetValues(target=120, collected_data=(50, 25, 16)),
     PeriodicTargetValues(target=130, collected_data=(50, 25, 17)),
     PeriodicTargetValues(target=140, collected_data=(50, 25, 18)), ]
-indicator_scenarios['scenario_1i-default_5pt_3cd'] = [IndicatorValues(
+indicator_scenarios['scenario_1i-default_5pt_3cd'] = Scenario(indicators=[IndicatorValues(
     lop_target=20,
-    periodic_targets=pts)]
+    periodic_targets=pts)])
 
 # Create 1 indicator with default indicator settings.  Create 5 periodic targets.
 pts = [
@@ -47,10 +53,10 @@ pts = [
     PeriodicTargetValues(target=120.5, collected_data=(50, 25, 16)),
     PeriodicTargetValues(target=130, collected_data=(50, 25, 17.93)),
     PeriodicTargetValues(target=140, collected_data=(50.29, 25, 18)), ]
-indicator_scenarios['scenario_1i-cumulative_number_5pt_3cd'] = [IndicatorValues(
+indicator_scenarios['scenario_1i-cumulative_number_5pt_3cd'] = Scenario(indicators=[IndicatorValues(
     lop_target=30,
     periodic_targets=pts,
-    is_cumulative=True)]
+    is_cumulative=True)])
 
 # Create 1 indicator with default indicator settings.  Create 5 periodic targets.
 pts = [
@@ -59,19 +65,40 @@ pts = [
     PeriodicTargetValues(target=.70, collected_data=(.50, .10, 0)),
     PeriodicTargetValues(target=.80, collected_data=(.40, .20, .20)),
     PeriodicTargetValues(target=.90, collected_data=(.50, .20, .10)), ]
-indicator_scenarios['scenario_1i-cumulative_percent_5pt_3cd'] = [IndicatorValues(
+indicator_scenarios['scenario_1i-cumulative_percent_5pt_3cd'] = Scenario(indicators=[IndicatorValues(
     unit_of_measure_type=Indicator.PERCENTAGE,
     lop_target=.80,
     periodic_targets=pts,
-    is_cumulative=True)]
+    is_cumulative=True)])
 
-# Create 1 indicator with default indicator settings.  Create 5 periodic targets.
+# Create 4 indicators with default indicator settings. Each indicator has a a different level of achieved vs target
+indicators_values = []
 pts = [
     PeriodicTargetValues(target=100, collected_data=(50, 25, 15), evidence=(True, False, True)),
     PeriodicTargetValues(target=110, collected_data=(0, 25, 50), evidence=(True, True, True)),
     PeriodicTargetValues(target=120, collected_data=(50, 25, 16), evidence=(False, False, True)),
     PeriodicTargetValues(target=130, collected_data=(50, 25, 17), evidence=(False, False, False)),
     PeriodicTargetValues(target=140, collected_data=(50, 25, 18), evidence=(False, False, True)), ]
-indicator_scenarios['scenario_1i-default_5pt_3cd_7ev'] = [IndicatorValues(
-    lop_target=20,
-    periodic_targets=pts)]
+indicators_values.append(IndicatorValues(lop_target=20, periodic_targets=pts))
+pts = [
+    PeriodicTargetValues(target=100, collected_data=(50, 25, 15), evidence=(True, False, True)),
+    PeriodicTargetValues(target=110, collected_data=(0, 25, 50), evidence=(True, True, True)),
+    PeriodicTargetValues(target=120, collected_data=(50, 25, 16), evidence=(False, False, True)),
+    PeriodicTargetValues(target=130, collected_data=(50, 25, 17), evidence=(False, False, False)),
+    PeriodicTargetValues(target=140, collected_data=(50, 25, 18), evidence=(False, False, True)), ]
+indicators_values.append(IndicatorValues(lop_target=20, periodic_targets=pts))
+pts = [
+    PeriodicTargetValues(target=100, collected_data=(50, 25, 15), evidence=(True, False, True)),
+    PeriodicTargetValues(target=110, collected_data=(0, 25, 50), evidence=(True, True, True)),
+    PeriodicTargetValues(target=120, collected_data=(50, 25, 16), evidence=(False, False, True)),
+    PeriodicTargetValues(target=130, collected_data=(50, 25, 17), evidence=(False, False, False)),
+    PeriodicTargetValues(target=140, collected_data=(50, 25, 18), evidence=(False, False, True)), ]
+indicators_values.append(IndicatorValues(lop_target=20, periodic_targets=pts))
+pts = [
+    PeriodicTargetValues(target=100, collected_data=(50, 25, 15), evidence=(True, False, True)),
+    PeriodicTargetValues(target=110, collected_data=(0, 25, 50), evidence=(True, True, True)),
+    PeriodicTargetValues(target=120, collected_data=(50, 25, 16), evidence=(False, False, True)),
+    PeriodicTargetValues(target=130, collected_data=(50, 25, 17), evidence=(False, False, False)),
+    PeriodicTargetValues(target=140, collected_data=(50, 25, 18), evidence=(False, False, True)), ]
+indicators_values.append(IndicatorValues(lop_target=20, periodic_targets=pts))
+indicator_scenarios['scenario_1i-default_5pt_3cd_7ev'] = Scenario(indicators=indicators_values)


### PR DESCRIPTION
- Add Scenario class which will carry methods for program level statistics
- Add scope statistic to ProgramPage context
- Add achieved-ratio getter for indicators in a Scenario
- Add a test for the three overall on-scope stats (low, high, and on-scope)
- Add multi-indicator scenario for testing stats
- Add ONSCOPE_MARGIN constant to Indicator model
- Put all remaining ScenarioBase tests into the IndicatorDetailMixin, in the hopes of providing better abstraction of the XBase classes.
- Created IndicatorStatsMixin to hold program level statistics tests