### PR TITLE
#468 test iptt

### DIFF
--- a/indicators/tests/test_reports.py
+++ b/indicators/tests/test_reports.py
@@ -283,7 +283,7 @@ class IPTT_MixinTests(TestCase):
     def test_get_context_data(self):
         '''Does get_context_data return existing data untouched
         and without inserting new data?'''
-        # self.skipTest('WIP')
+        self.skipTest('WIP')
         request = HttpRequest()
         request.user = self.user
         kwargs = {
@@ -296,7 +296,6 @@ class IPTT_MixinTests(TestCase):
             'program_id': self.program.id,
         }
         result = render(request, 'indicators/iptt_quickstart.html', context=context)
-        print dir(result)
 
 
 class IPTT_ReportIndicatorsWithVariedStartDateTests(TestCase):

--- a/indicators/tests/test_reports.py
+++ b/indicators/tests/test_reports.py
@@ -1,8 +1,7 @@
 import datetime
 import urllib
 
-from django.http import HttpRequest, QueryDict
-from django.shortcuts import render
+from django.http import QueryDict
 from django.test import Client, RequestFactory, TestCase
 
 from factories.indicators_models import IndicatorFactory
@@ -279,23 +278,14 @@ class IPTT_MixinTests(TestCase):
     def test_prepare_iptt_period_dateranges(self):
         self.skipTest('TODO: Test not implemented')
 
-    # TODO: Finish this test
+    # TODO: Finish this test; don't know how test it cleanly. IPTT_Mixin
+    # doesn't implement get_context_data and calls the superclass' version.
+    # The test would end up testing Django's TemplateView instead of our
+    # IPTT_Mixin.
     def test_get_context_data(self):
         '''Does get_context_data return existing data untouched
         and without inserting new data?'''
-        self.skipTest('WIP')
-        request = HttpRequest()
-        request.user = self.user
-        kwargs = {
-            'prefix': 'targetperiods',
-            'request': request,
-        }
-        context = {
-            'targetprefix': 'targetperiods',
-            'timeprefix': 'timeperiods',
-            'program_id': self.program.id,
-        }
-        result = render(request, 'indicators/iptt_quickstart.html', context=context)
+        self.skipTest('TODO: Test not implemented')
 
 
 class IPTT_ReportIndicatorsWithVariedStartDateTests(TestCase):

--- a/indicators/tests/test_reports.py
+++ b/indicators/tests/test_reports.py
@@ -1,7 +1,8 @@
 import datetime
 import urllib
 
-from django.http import QueryDict
+from django.http import HttpRequest, QueryDict
+from django.shortcuts import render
 from django.test import Client, RequestFactory, TestCase
 
 from factories.indicators_models import IndicatorFactory
@@ -244,6 +245,7 @@ class IPTT_MixinTests(TestCase):
             self.assertEqual(str(data[k]), str(formdata[k]))
 
     def test__get_filters_with_no_periods(self):
+
         data = {
             'level': 'Outcome',
             'sector': 'Conflict Management',
@@ -268,8 +270,8 @@ class IPTT_MixinTests(TestCase):
         self.assertEqual(data['site'], *filters['collecteddata__site__in'])
         self.assertEqual(data['indicators'], *filters['id__in'])
 
-        # Assert things about the report contents.
-        # TODO: Is this possible without submitting the filters?
+        # TODO: Is it possible to make assertions about the filtered report
+        # TODO: without a GET or POST?
 
     def test_prepare_indicators(self):
         self.skipTest('TODO: Test not implemented')
@@ -277,8 +279,24 @@ class IPTT_MixinTests(TestCase):
     def test_prepare_iptt_period_dateranges(self):
         self.skipTest('TODO: Test not implemented')
 
+    # TODO: Finish this test
     def test_get_context_data(self):
-        self.skipTest('TODO: Test not implemented')
+        '''Does get_context_data return existing data untouched
+        and without inserting new data?'''
+        # self.skipTest('WIP')
+        request = HttpRequest()
+        request.user = self.user
+        kwargs = {
+            'prefix': 'targetperiods',
+            'request': request,
+        }
+        context = {
+            'targetprefix': 'targetperiods',
+            'timeprefix': 'timeperiods',
+            'program_id': self.program.id,
+        }
+        result = render(request, 'indicators/iptt_quickstart.html', context=context)
+        print dir(result)
 
 
 class IPTT_ReportIndicatorsWithVariedStartDateTests(TestCase):


### PR DESCRIPTION
Poked at testing `IPTT_Mixin.get_context_data`. I don't know how to do it. From the fine commit:

>I don't know how test it cleanly. `IPTT_Mixin` doesn't implement  `get_context_data` and calls the superclass' version, which I think ends up being `TemplateView.get_context_data`. The test would validate Django's `TemplateView` instead of our `IPTT_Mixin`. I think.