### PR TITLE
Fixes #638, bad period selector, and #639, midline/endline target saving issues.

### DIFF
--- a/indicators/forms.py
+++ b/indicators/forms.py
@@ -14,9 +14,9 @@ from workflow.models import (
 from tola.util import getCountry
 from indicators.models import (
     Indicator, PeriodicTarget, CollectedData, Objective, StrategicObjective,
-    TolaTable, DisaggregationType,
-    Level, IndicatorType
+    TolaTable, DisaggregationType, Level, IndicatorType
 )
+from indicators.widgets import DataAttributesSelect
 
 locale_format = formats.get_format('DATE_INPUT_FORMATS', lang=translation.get_language())[-1]
 
@@ -169,9 +169,20 @@ class CollectedDataForm(forms.ModelForm):
         except TypeError:
             pass
 
-        self.fields['periodic_target'].queryset = PeriodicTarget.objects\
-            .filter(indicator=self.indicator)\
+        # Django will deliver localized strings to the template but the form needs to be able to compare the date
+        # entered to the start and end dates of each period.  Data attributes (attached to each option element) are
+        # used to provide access to the start and end dates in ISO format, since they are easier to compare to than
+        # the localized date strings.
+        periodic_targets = PeriodicTarget.objects \
+            .filter(indicator=self.indicator) \
             .order_by('customsort', 'create_date', 'period')
+        data = {'data-start': {'': ''}, 'data-end': {'': ''}}
+        choices = []
+        for pt in periodic_targets:
+            data['data-start'].update({str(pt.id): pt.start_date})
+            data['data-end'].update({str(pt.id): pt.end_date})
+            choices.append((pt.id, str(pt)))
+        self.fields['periodic_target'].widget = DataAttributesSelect(data=data, choices=choices)
 
         self.fields['program2'].initial = self.program
         self.fields['program2'].label = _("Program")

--- a/indicators/models.py
+++ b/indicators/models.py
@@ -642,7 +642,7 @@ class PeriodicTarget(models.Model):
         verbose_name = _("Periodic Target")
 
     def __unicode__(self):
-        # can't find where this surfaces in the UI
+        # used in the collected data modal to display options in the target period dropdown
         if self.indicator.target_frequency == Indicator.LOP \
             or self.indicator.target_frequency == Indicator.EVENT \
                 or self.indicator.target_frequency == Indicator.MID_END:

--- a/indicators/views/views_indicators.py
+++ b/indicators/views/views_indicators.py
@@ -564,14 +564,14 @@ class IndicatorUpdate(UpdateView):
                 try:
                     start_date = dateparser.parse(pt.get('start_date', None))
                     start_date = datetime.strftime(start_date, '%Y-%m-%d')
-                except ValueError:
+                except (ValueError, TypeError):
                     # raise ValueError("Incorrect data value")
                     start_date = None
 
                 try:
                     end_date = dateparser.parse(pt.get('end_date', None))
                     end_date = datetime.strftime(end_date, '%Y-%m-%d')
-                except ValueError:
+                except (ValueError, TypeError):
                     # raise ValueError("Incorrect data value")
                     end_date = None
 
@@ -647,7 +647,6 @@ class IndicatorUpdate(UpdateView):
                 "content": content,
                 "remove_missing_targts_link": remove_missing_targts_link
             }
-            print("remove_missing_targts_link={}".format(remove_missing_targts_link))
             return HttpResponse(json.dumps(data))
         else:
             messages.success(self.request, _('Success, Indicator Updated!'))

--- a/indicators/widgets.py
+++ b/indicators/widgets.py
@@ -1,0 +1,17 @@
+from django.forms.widgets import Select
+
+
+class DataAttributesSelect(Select):
+
+    def __init__(self, attrs=None, choices=(), data=None):
+        super(DataAttributesSelect, self).__init__(attrs, choices)
+        if not data:
+            data = {}
+        self.data = data
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        option = super(DataAttributesSelect, self).create_option(
+            name, value, label, selected, index, subindex=None, attrs=None)
+        for data_attr, values in self.data.iteritems():
+            option['attrs'][data_attr] = values[option['value']]
+        return option

--- a/templates/indicators/collecteddata_form_common_js.html
+++ b/templates/indicators/collecteddata_form_common_js.html
@@ -160,10 +160,9 @@
             if (!pt_date_range || pt_date_range == null || pt_date_range == 'null'){
                 return;
             }
-            pt_date_range = pt_date_range[1].split('-');
             try {
-                var start_date = new Date(pt_date_range[0].trim());
-                var end_date = new Date(pt_date_range[1].trim());
+                var start_date = new Date($(this).data("start"));
+                var end_date = new Date($(this).data("end"));
                 var collected_date = new Date($("#id_date_collected").val().trim());
                 if (collected_date >= start_date && collected_date <= end_date) {
                     // deselect the currently selected option


### PR DESCRIPTION
For #638, adds a ISO formatted date as a data attribute to each period option.  This date, rather than the date string, is used for testing which period is the right one to assign.

For #651, adds exception handling for missing dates.