### PR TITLE
665 add documents only active programs

### DIFF
--- a/workflow/forms.py
+++ b/workflow/forms.py
@@ -1450,7 +1450,7 @@ class DocumentationForm(forms.ModelForm):
         self.fields['url'].widget = URLInput()
         self.fields['url'].required = True
         self.fields['project'].queryset = ProjectAgreement.objects.filter(program__country__in=countries)
-        self.fields['program'].queryset = Program.objects.filter(country__in=countries)
+        self.fields['program'].queryset = Program.active_programs.filter(country__in=countries)
 
 
 class QuantitativeOutputsForm(forms.ModelForm):

--- a/workflow/models.py
+++ b/workflow/models.py
@@ -325,6 +325,13 @@ class FundCodeAdmin(admin.ModelAdmin):
     display = 'Fund Code'
 
 
+class ActiveProgramsManager(models.Manager):
+    ACTIVE_FUNDING_STATUS = 'funded'
+    def get_queryset(self):
+        return super(ActiveProgramsManager, self).get_queryset().filter(
+            funding_status__iexact=self.ACTIVE_FUNDING_STATUS)
+
+
 class Program(models.Model):
     gaitid = models.CharField(_("ID"), max_length=255, blank=True, unique=True)
     name = models.CharField(_("Program Name"), max_length=255, blank=True)
@@ -343,6 +350,9 @@ class Program(models.Model):
     end_date = models.DateField(_("Program End Date"), null=True, blank=True)
     reporting_period_start = models.DateField(_("Reporting Period Start Date"), null=True, blank=True)
     reporting_period_end = models.DateField(_("Reporting Period End Date"), null=True, blank=True)
+
+    objects = models.Manager()
+    active_programs = ActiveProgramsManager()
 
     class Meta:
         verbose_name = _("Program")

--- a/workflow/models.py
+++ b/workflow/models.py
@@ -326,6 +326,7 @@ class FundCodeAdmin(admin.ModelAdmin):
 
 
 class ActiveProgramsManager(models.Manager):
+    """manager to return only active programs - those with a status of 'funded' or 'Funded'"""
     ACTIVE_FUNDING_STATUS = 'funded'
     def get_queryset(self):
         return super(ActiveProgramsManager, self).get_queryset().filter(


### PR DESCRIPTION
Closes #665 
(disregard the commit message where I claimed this closes 657, obviously this does not do that thing)
Added active programs manager to programs
Changed document create form to use that method.
Question for @jennyhavah:
the following forms also use a list of programs (and don't currently check for "active" status) should any of them be similarly updated?
TrainingAttendanceForm (used in creating and updating a training record <tola>/formlibrary/training_add/0/)
DistributionForm (used in creating and updating a distribution list (<tola>/formlibrary/distribution_add/0/)
