### PR TITLE
Closes #479 - submit button disabled while ajax response is pending, …

### DIFF
--- a/templates/indicators/indicator_form_common_js.html
+++ b/templates/indicators/indicator_form_common_js.html
@@ -297,7 +297,8 @@
         if (form_data.indexOf('is_cumulative') == -1) {
             form_data += "&is_cumulative=3"
         }
-
+        //disable submit button as we are posting and want to prevent double-saves while waiting: 
+        submitBtnName.attr('disabled', true);
         $("#modalmessages").html("<img src='{{ STATIC_URL }}/img/ajax-loader.gif'>  <span>{% trans 'Saving form... please wait.'|escapejs %}</span>");
         $.ajax({
             method: 'POST',
@@ -305,6 +306,8 @@
             data: form_data,
             global: false, }
         ).done(function(data, textStatus, jqXHR) {
+            //undisable submit button as the response is returned:
+            $('input[type=submit]:disabled').attr('disabled', false);
             var alertsElement = "#alerts";
             if ( $("#modalmessages").length) {
                 alertsElement = "#modalmessages";

--- a/templates/indicators/indicator_form_common_js.html
+++ b/templates/indicators/indicator_form_common_js.html
@@ -299,6 +299,8 @@
         }
         //disable submit button as we are posting and want to prevent double-saves while waiting: 
         submitBtnName.attr('disabled', true);
+        // adding button to an Object so it is available inside the success callback
+        var disabledButton = {'submit': submitBtnName};
         $("#modalmessages").html("<img src='{{ STATIC_URL }}/img/ajax-loader.gif'>  <span>{% trans 'Saving form... please wait.'|escapejs %}</span>");
         $.ajax({
             method: 'POST',
@@ -307,7 +309,7 @@
             global: false, }
         ).done(function(data, textStatus, jqXHR) {
             //undisable submit button as the response is returned:
-            $('input[type=submit]:disabled').attr('disabled', false);
+            disabledButton.submit.attr('disabled', false);
             var alertsElement = "#alerts";
             if ( $("#modalmessages").length) {
                 alertsElement = "#modalmessages";


### PR DESCRIPTION
…preventing anyone from "hitting Save changes repeatedly like a crazy person"

- tested on both update and create indicator forms (add indicator from indicators page, and the gear icon from the indicators page) - submit button disabled on submit, reenabled on either successful or unsuccessful save (errors).  Prevents multiple submits and any ensuing backend chaos.