### PR TITLE
Addresses & potentially closes #559

### DIFF
--- a/scss/_bootstrap_multiselect.scss
+++ b/scss/_bootstrap_multiselect.scss
@@ -148,6 +148,7 @@ span.multiselect-native-select select{
     align-items: center;
     color: $gray-700;
     display: flex;
+    font-weight: $font-weight-normal;
     justify-content: space-between;
     text-align: left;
     width: 100%;

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,6 +77,9 @@
                         </div>
 
                         <ul class="navbar-nav">
+                            <li class="nav-item pr-2 mr-3">
+                                <a class="nav-link" href="{% url 'indicator_list' 0 0 0 %}">{% trans "Indicators" %}</a>
+                            </li>
                             <li class="nav-item dropdown pr-2 mr-3">
                                 <a class="nav-link dropdown-toggle" href="#" id="navbarBrowse" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{% trans "Browse" %}</a>
                                 <div class="dropdown-menu" aria-labelledby="navbarBrowse">

--- a/templates/indicators/collected_data_table.html
+++ b/templates/indicators/collected_data_table.html
@@ -297,7 +297,7 @@
         {% endif %}
         </div>
         <div class="{% if indicator.target_frequency == None or err == 'Error_1' %} disable-span {% endif %}">
-            <a href="{% url 'collecteddata_add' program_id indicator.id %}" class="btn btn-success collected-data__link"><i class="fas fa-plus-circle"></i> {% trans "Add results" %}</a>
+            <a href="{% url 'collecteddata_add' program_id indicator.id %}" class="btn-link btn-add collected-data__link"><i class="fas fa-plus-circle"></i> {% trans "Add results" %}</a>
         </div>
     </div>
 {% else %}

--- a/templates/indicators/filter.html
+++ b/templates/indicators/filter.html
@@ -156,4 +156,43 @@
     $("#id_indicatortypes_filter_dropdown").on("multiselect:select multiselect:unselecting", function(e) {
         $("#type_filter_value").data('typeid', 0);
     });
+
+    // Filters
+    function getUrl() {
+        var programId = $("#program_filter_value").data('programid');
+        var indicatorId = $("#indicator_filter_value").data('indicatorid');
+        var typeId = $("#type_filter_value").data('typeid');
+        var url = '/indicators/home/';
+
+        url += (parseInt(programId) >= 0 ? programId : 0) + '/';
+        url += (parseInt(indicatorId) >= 0 ? indicatorId : 0) + '/';
+        url += (parseInt(typeId) >= 0 ? typeId : 0 ) + '/';
+        return url;
+    }
+    $("#id_filtersDropdown").on("programFilterUpdated", "#id_programs_filter_dropdown", function(e){
+        var url = getUrl();
+        window.location.href = url;
+    });
+
+    $("#id_filtersDropdown").on("indicatorFilterUpdated", "#id_indicators_filter_dropdown", function(e){
+        var url = getUrl();
+        sessionStorage.setItem("openProgram", "true");
+        window.location.href = url;
+    });
+
+
+    $("#id_filtersDropdown").on("indicatorTypeFilterUpdated", "#id_indicatortypes_filter_dropdown", function(e){
+        var url = getUrl();
+        window.location.href = url;
+    });
+
+    window.onload = function() {
+        var programId = `{{ programs.0.id }}`;
+
+        if (sessionStorage.getItem('openProgram')) {
+            sessionStorage.removeItem("openProgram");
+            loadIndicators(programId, indicatorId, 0);
+            $("#hidden-"+programId).collapse('show');
+        }
+    }
 </script>

--- a/templates/indicators/indicator_list.html
+++ b/templates/indicators/indicator_list.html
@@ -28,7 +28,10 @@
                         </a>
                     </div>
                 {% elif not program.indicator_set.all %}
-                    <div class="">{% trans "No Indicators have been entered for this program" %}</div>
+                    <div class="">
+                        <p>{% trans "No Indicators have been entered for this program" %}</p>
+                        <a href="{% url 'indicator_create' program.id %}" role="button" class="btn-link btn-add"><i class="fas fa-plus-circle"></i> {% trans "Add indicator" %}</a>
+                    </div>
                 {% else %}
                     <a
                         id="id_btnOpenindicatorsForProgramId_{{ program.id }}"
@@ -84,46 +87,7 @@
 
 {% include "indicators/indicator_list_modals.html" %}
 
-<script type="javascript">
-    // Filters
-    function getUrl() {
-        var programId = $("#program_filter_value").data('programid');
-        var indicatorId = $("#indicator_filter_value").data('indicatorid');
-        var typeId = $("#type_filter_value").data('typeid');
-        var url = '/indicators/home/';
 
-        url += (parseInt(programId) >= 0 ? programId : 0) + '/';
-        url += (parseInt(indicatorId) >= 0 ? indicatorId : 0) + '/';
-        url += (parseInt(typeId) >= 0 ? typeId : 0 ) + '/';
-        return url;
-    }
-    $("#id_filtersDropdown").on("programFilterUpdated", "#id_programs_filter_dropdown", function(e){
-        var url = getUrl();
-        window.location.href = url;
-    });
-
-    $("#id_filtersDropdown").on("indicatorFilterUpdated", "#id_indicators_filter_dropdown", function(e){
-        var url = getUrl();
-        sessionStorage.setItem("openProgram", "true");
-        window.location.href = url;
-    });
-
-
-    $("#id_filtersDropdown").on("indicatorTypeFilterUpdated", "#id_indicatortypes_filter_dropdown", function(e){
-        var url = getUrl();
-        window.location.href = url;
-    });
-
-    window.onload = function() {
-        var programId = `{{ programs.0.id }}`;
-
-        if (sessionStorage.getItem('openProgram')) {
-            sessionStorage.removeItem("openProgram");
-            loadIndicators(programId, indicatorId, 0);
-            $("#hidden-"+programId).collapse('show');
-        }
-    }
- </script>
 {% include 'indicators/indicator_form_common_js.html' %}
 {% include 'indicators/collecteddata_form_common_js.html' %}
 {% endblock content %}

--- a/templates/indicators/indicator_list.html
+++ b/templates/indicators/indicator_list.html
@@ -10,7 +10,7 @@
     {% for program in programs %}
         <div class='card border-0 program indicators-list__program'>
             <div class='card-header'>
-                <h4><a href="{% url 'program_page' program.id 0 0 %}">{{ program.name|truncatechars:140 }}</a></h4>
+                <h4>{{ program.name|truncatechars:140 }}</h4>
                 {% if not program.reporting_period_start or not program.reporting_period_end %}
                     <div class="">
                         {% trans "Before adding indicators and performance results, we need to know your program's " %}

--- a/tola/static/css/tola.css
+++ b/tola/static/css/tola.css
@@ -6112,6 +6112,7 @@ span.multiselect-native-select select {
   align-items: center;
   color: #54585a;
   display: flex;
+  font-weight: 400;
   justify-content: space-between;
   text-align: left;
   width: 100%; }


### PR DESCRIPTION
Provides cosmetic updates and partially refactored frontend code for the __Indicator List__ and __Indicator Filter__ components, tangential to #559. Indicator List appears on the `/indicators/*` page (pre-Mangosteen) and is included on the `/programs/*` page (post-Mangosteen). Program page is stealthily deployed but partially complete — gauges and sidebar are not functional. See http://127.0.0.1:8000/program/442/0/0/ for example. 

![image](https://user-images.githubusercontent.com/169060/47104438-4be10c00-d1f6-11e8-83d1-664cd9b47c93.png)

![image](https://user-images.githubusercontent.com/169060/47104450-53a0b080-d1f6-11e8-96dc-291d9f38bd29.png)

![image](https://user-images.githubusercontent.com/169060/47104531-8c408a00-d1f6-11e8-94a9-a33b507a8b70.png)
