### PR TITLE
Fixes #662 (datepicker triggers on clicked whitespace)

### DIFF
--- a/templates/indicators/collecteddata_form_modal.html
+++ b/templates/indicators/collecteddata_form_modal.html
@@ -29,6 +29,8 @@
 
             var achieved_formatted_value = parseFloat($("#id_achieved").val()).toFixed(2).replace(/[.,]00$/, "");
             $("#id_achieved").val(achieved_formatted_value);
+            //this prevents clicking the whitespace to the left of the datepicker from triggering it:
+            $('label[for="id_date_collected"]').on('click', function(e) {e.preventDefault();});
 
             $('#id_date_collected').on('click', function (e) {
                 windowScrollY = $(this).scrollParent().scrollParent().scrollTop(); // how much the window has been scrolled


### PR DESCRIPTION
Suppressed the default browser behavior of click on label triggers focus to input
@sanjuroj - do we want to apply this to other datepicker elements?