### PR TITLE
insert_final_newline is boolean

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ indent_size = 4
 # The JSON files contain newlines inconsistently
 [*.json]
 indent_size = 4
-insert_final_newline = ignore
+insert_final_newline = true
 
 [**/admin/js/vendor/**]
 indent_style = ignore
@@ -29,7 +29,7 @@ indent_size = ignore
 # Minified JavaScript files shouldn't be changed
 [**.min.js]
 indent_style = ignore
-insert_final_newline = ignore
+insert_final_newline = true
 
 # Makefiles always use tabs for indentation
 [Makefile]


### PR DESCRIPTION
Editorconfig's `insert_final_newline` statement requires booleans. In addtion, PEP8 requires a terminal newline, so just make that the default across all file types.