### PR TITLE
Program Queries with tests

### DIFF
--- a/factories/indicators_models.py
+++ b/factories/indicators_models.py
@@ -14,8 +14,10 @@ from indicators.models import (
     Objective as ObjectiveM,
     PeriodicTarget as PeriodicTargetM,
     StrategicObjective as StrategicObjectiveM,
+    DisaggregationType as DisaggregationTypeM,
+    DataCollectionFrequency as DataCollectionFrequencyM
 )
-from workflow_models import OrganizationFactory, ProgramFactory
+from workflow_models import OrganizationFactory, ProgramFactory, CountryFactory
 
 FAKER = faker.Faker(locale='en_US')
 
@@ -76,6 +78,20 @@ class IndicatorFactory(DjangoModelFactory):
         else:
             pass
 
+
+class DefinedIndicatorFactory(IndicatorFactory):
+    number = Sequence(lambda n: '1.1.{0}'.format(n))
+    source = "indicator source"
+    definition = "indicator definition"
+    justification = "rationale or justification"
+    unit_of_measure = "a unit of measure"
+    unit_of_measure_type = IndicatorM.NUMBER
+    baseline = 100
+    lop_target = 1000
+    target_frequency = IndicatorM.QUARTERLY
+    means_of_verification = "some means of verifying"
+    data_collection_method = "some method of collecting data"
+    data_collection_frequency = SubFactory('factories.indicators_models.DataCollectionFrequencyFactory')
 
 class Objective(DjangoModelFactory):
     class Meta:
@@ -140,3 +156,18 @@ class PeriodicTargetFactory(DjangoModelFactory):
     target = 0
     period = lazy_attribute(
         lambda pt: 'PeriodicTarget for %s: %s - %s' % (pt.indicator.name, pt.start_date, pt.end_date))
+
+class DisaggregationTypeFactory(DjangoModelFactory):
+    class Meta:
+        model = DisaggregationTypeM
+    disaggregation_type = Sequence(lambda n: "disagg type {0}".format(n))
+    description = "disaggregation description"
+    country = SubFactory(CountryFactory)
+
+class DataCollectionFrequencyFactory(DjangoModelFactory):
+    class Meta:
+        model = DataCollectionFrequencyM
+
+    frequency = "some reasonable frequency"
+    description = "a description of how frequent this is"
+    numdays = 10

--- a/factories/indicators_models.py
+++ b/factories/indicators_models.py
@@ -113,6 +113,7 @@ class CollectedDataFactory(DjangoModelFactory):
 
     program = SubFactory(ProgramFactory)
     indicator = SubFactory(IndicatorFactory)
+    description = Sequence(lambda n: 'Data description {0}'.format(n))
     achieved = 10
 
     @post_generation

--- a/indicators/models.py
+++ b/indicators/models.py
@@ -313,6 +313,7 @@ class Indicator(models.Model):
         (DIRECTION_OF_CHANGE_POSITIVE, _("Increase (+)")),
         (DIRECTION_OF_CHANGE_NEGATIVE, _("Decrease (-)"))
     )
+    SEPARATOR = ','
 
     indicator_key = models.UUIDField(
         default=uuid.uuid4, unique=True, help_text=" "),
@@ -575,7 +576,7 @@ class Indicator(models.Model):
     @property
     def disaggregations(self):
         disaggregations = self.disaggregation.all()
-        return ', '.join([x.disaggregation_type for x in disaggregations])
+        return self.SEPARATOR.join([x.disaggregation_type for x in disaggregations])
 
     @property
     def get_target_frequency_label(self):

--- a/indicators/models.py
+++ b/indicators/models.py
@@ -713,7 +713,7 @@ class CollectedData(models.Model):
         _("Remarks/comments"), blank=True, null=True, help_text=" ")
 
     indicator = models.ForeignKey(
-        Indicator, help_text=" ", verbose_name=_("Indicator")
+        Indicator, help_text=" ", verbose_name=_("Indicator"),
     )
 
     agreement = models.ForeignKey(

--- a/indicators/queries.py
+++ b/indicators/queries.py
@@ -8,6 +8,8 @@ from indicators.models import (
     PeriodicTarget,
     CollectedData
 )
+from datetime import date
+from workflow import models as wf_models
 from django.db import models
 from django.db.models.functions import Concat
 #from django.db.models import Sum, Avg, Subquery, OuterRef, Case, When, Q, F, Max
@@ -16,38 +18,74 @@ class Round(models.Func):
     function = 'ROUND'
     template = '%(function)s(%(expressions)s, 0)'
 
+
 class IPTTIndicatorQuerySet(models.QuerySet):
     pass
+
 
 class IPTTIndicatorManager(models.Manager):
     def get_lop_target_annotations(self):
         """generates annotations for LOP target and actual data
 
         takes into account cumulative/noncumulative and number/percent"""
-        indicator_targets = PeriodicTarget.objects.filter(
-            indicator=models.OuterRef('pk')
+        # we only want targets that are either time naive or for completed periods:
+        data_subquery = CollectedData.objects.filter(
+            periodic_target_id=models.OuterRef('pk')
+        )
+        indicator_targets = PeriodicTarget.objects.annotate(
+            data_count=models.Subquery(
+                data_subquery.annotate(total=models.Count('achieved')).values('total')[:1],
+                output_field=models.IntegerField()
+            )
+        ).filter(
+            models.Q(indicator=models.OuterRef('pk')),
+            (
+                models.Q(indicator__target_frequency__in=[Indicator.LOP, Indicator.MID_END, Indicator.EVENT]) &
+                models.Q(data_count__gt=0)
+            ) | models.Q(end_date__lte=date.today())
         )
         indicator_data = CollectedData.objects.filter(
-            indicator=models.OuterRef('pk')
+            models.Q(indicator=models.OuterRef('pk'))
         )
         lop_target_sum = models.Case(
             models.When(
-                is_cumulative=False,
-                then=models.Subquery(
-                    indicator_targets.order_by().values(
-                        'indicator_id'
-                    ).annotate(
-                        total=models.Sum('target')
-                    ).values('total'),
+                # the only target for a LOP indicator is the "lop_target" value on the indicator itself:
+                target_frequency=Indicator.LOP,
+                then=models.ExpressionWrapper(
+                    models.F('lop_target'),
                     output_field=models.FloatField()
                 )
             ),
             models.When(
+                # cumulative indicator means sort and take the most recent:
                 is_cumulative=True,
-                then=models.Subquery(
-                    indicator_targets.order_by('-end_date').values('target')[:1],
-                    output_field=models.FloatField()))
+                then=models.Case(
+                    # midline/endling and event indicators sort on customsort (with fallbacks)
+                    models.When(
+                        target_frequency__in=[Indicator.MID_END, Indicator.EVENT],
+                        then=models.Subquery(
+                            indicator_targets.order_by(
+                                '-customsort', '-end_date', '-create_date'
+                            ).values('target')[:1],
+                            output_field=models.FloatField()
+                        )
+                    ),
+                    # not midline/endline means it's time-aware, sort on end_date:
+                    default=models.Subquery(
+                        indicator_targets.order_by('-end_date').values('target')[:1],
+                        output_field=models.FloatField())
+                    )
+            ),
+            default=models.Subquery(
+                indicator_targets.order_by().values(
+                    'indicator_id'
+                ).annotate(
+                    total=models.Sum('target')
+                ).values('total'),
+                output_field=models.FloatField()
+            )
         )
+        # lop_actual_sum = sum of all the data collected:
         lop_actual_sum = models.Case(
             models.When(
                 unit_of_measure_type=Indicator.PERCENTAGE,
@@ -83,14 +121,83 @@ class IPTTIndicatorManager(models.Manager):
     def get_queryset(self):
         annotations = self.get_labeling_annotations()
         annotations.update(self.get_lop_target_annotations())
-        return super(IPTTIndicatorManager, self).get_queryset().annotate(
+        return IPTTIndicatorQuerySet(self.model, using=self._db).annotate(
             **annotations
+        ).annotate(
+            lop_met_real=models.Case(
+                models.When(
+                    models.Q(lop_target_sum__isnull=True) |
+                    models.Q(lop_actual_sum__isnull=True),
+                    then=models.Value(None)
+                    ),
+                default=models.ExpressionWrapper(
+                    models.F('lop_actual_sum') / models.F('lop_target_sum'),
+                    output_field=models.FloatField()
+                )
+            )
+        ).annotate(
+            over_under=models.Case(
+                models.When(
+                    lop_met_real__isnull=True,
+                    then=models.Value(None)
+                    ),
+                models.When(
+                    models.Q(lop_met_real__gt=1.15) &
+                    models.Q(direction_of_change=Indicator.DIRECTION_OF_CHANGE_NEGATIVE),
+                    then=models.Value(-1)
+                    ),
+                models.When(
+                    lop_met_real__gt=1.15,
+                    then=models.Value(1)
+                ),
+                models.When(
+                    models.Q(lop_met_real__lt=0.85) &
+                    models.Q(direction_of_change=Indicator.DIRECTION_OF_CHANGE_NEGATIVE),
+                    then=models.Value(1)
+                ),
+                models.When(
+                    lop_met_real__lt=0.85,
+                    then=models.Value(-1)
+                ),
+                default=models.Value(0),
+                output_field=models.IntegerField(null=True)
+            )
         )
 
 class NoTargetsIndicatorManager(IPTTIndicatorManager):
 
-    def period(self, period_name, period_start, period_end):
-        return self.get_queryset().period(period_name, period_start, period_end)
+    def periods(self, periods):
+        """annotate a query with actual data sums for a set of time periods"""
+        period_annotations = {}
+        for c, period in enumerate(periods):
+            date_range = "{0}-{1}".format(
+                period['start_date'].strftime('%Y-%m-%d'),
+                period['end_date'].strftime('%Y-%m-%d')
+            )
+            period_annotations[date_range] = models.Case(
+                models.When(
+                    unit_of_measure_type=Indicator.PERCENTAGE,
+                    then=models.Subquery(
+                        CollectedData.objects.filter(
+                            indicator_id=models.OuterRef('pk'),
+                            date_collected__lte=period['end_date']
+                        ).order_by('-date_collected').values('achieved')[:1],
+                        output_field=models.FloatField()
+                    )),
+                default=models.Subquery(
+                    CollectedData.objects.filter(
+                        indicator_id=models.OuterRef('pk'),
+                        date_collected__lte=period['end_date']
+                    ).filter(
+                        models.Q(date_collected__gte=period['start_date']) |
+                        models.Q(indicator__is_cumulative=True)
+                    ).order_by().values('indicator_id').annotate(
+                        total=models.Sum('achieved')).values('total'),
+                    output_field=models.FloatField())
+            )
+            period_annotations["period_{0}".format(c)] = models.Value(
+                date_range, output_field=models.CharField())
+        return self.get_queryset().annotate(**period_annotations)
 
     def get_queryset(self):
         qs = super(NoTargetsIndicatorManager, self).get_queryset()
@@ -214,3 +321,97 @@ class IPTTIndicator(Indicator):
     @property
     def lop_met_target(self):
         return str(int(round(float(self.lop_actual_sum)*100/self.lop_target_sum))) + "%"
+
+    @property
+    def timeperiods(self):
+        if self.unit_of_measure_type == self.PERCENTAGE and self.is_cumulative == False:
+            return
+        else:
+            count = 0
+            while getattr(self, "period_{0}".format(count), None) is not None:
+                yield getattr(self, "period_{0}".format(count))
+                count += 1
+
+class ProgramWithMetricsManager(models.Manager):
+    pass
+
+class ProgramWithMetrics(wf_models.Program):
+    class Meta:
+        proxy = True
+
+    objects = ProgramWithMetricsManager()
+
+    def get_filters(self):
+        filters = []
+        if self.reporting_period_end > date.today():
+            # open program -> LOP targets are incomplete
+            filters.append(models.Q(target_frequency=Indicator.LOP))
+        # indicator with no periodic targets is incomplete (this field falls back to lop_target for lop indicators:
+        filters.append(models.Q(lop_target_sum__isnull=True))
+        filters.append(models.Q(lop_actual_sum__isnull=True))
+        return filters
+
+    @property
+    def nonreporting(self):
+        """returns indicators (annotated with target data) that are excluded from reporting metrics"""
+        qs = self.get_indicators()
+        filters = self.get_filters()
+        if filters:
+            filter_query = filters.pop()
+            for filt in filters:
+                filter_query |= filt
+            qs = qs.filter(filter_query)
+        return qs
+
+    @property
+    def reporting(self):
+        """returns indicators (annotated with target data) that are included in reporting metrics"""
+        qs = self.get_indicators()
+        excludes = self.get_filters()
+        if excludes:
+            exclude_query = excludes.pop()
+            for exclude in excludes:
+                exclude_query |= exclude
+            qs = qs.exclude(exclude_query)
+        return qs
+
+    def get_indicators(self):
+        return IPTTIndicator.withtargets.filter(program__in=[self.id])
+
+    def get_complete_indicators(self):
+        indicators = self.get_indicators()
+        if self.reporting_period_end > date.today():
+            indicators = indicators.exclude(
+                target_frequency__in=[Indicator.LOP]
+            )
+        return indicators
+
+    @property
+    def incomplete(self):
+        indicators = self.get_indicators()
+        if self.reporting_period_end > date.today():
+            indicators = indicators.filter(
+                target_frequency__in=[Indicator.LOP]
+            )
+        return indicators
+
+    @property
+    def ontarget(self):
+        indicators = self.get_complete_indicators().filter(
+            over_under=0
+        )
+        return indicators
+
+    @property
+    def undertarget(self):
+        indicators = self.get_complete_indicators().filter(
+            over_under=-1
+        )
+        return indicators
+
+    @property
+    def overtarget(self):
+        indicators = self.get_complete_indicators().filter(
+            over_under=1
+        )
+        return indicators

--- a/indicators/queries.py
+++ b/indicators/queries.py
@@ -332,14 +332,10 @@ class IPTTIndicator(Indicator):
                 yield getattr(self, "period_{0}".format(count))
                 count += 1
 
-class ProgramWithMetricsManager(models.Manager):
-    pass
-
 class ProgramWithMetrics(wf_models.Program):
     class Meta:
         proxy = True
 
-    objects = ProgramWithMetricsManager()
 
     def get_filters(self):
         filters = []
@@ -378,40 +374,23 @@ class ProgramWithMetrics(wf_models.Program):
     def get_indicators(self):
         return IPTTIndicator.withtargets.filter(program__in=[self.id])
 
-    def get_complete_indicators(self):
-        indicators = self.get_indicators()
-        if self.reporting_period_end > date.today():
-            indicators = indicators.exclude(
-                target_frequency__in=[Indicator.LOP]
-            )
-        return indicators
-
-    @property
-    def incomplete(self):
-        indicators = self.get_indicators()
-        if self.reporting_period_end > date.today():
-            indicators = indicators.filter(
-                target_frequency__in=[Indicator.LOP]
-            )
-        return indicators
-
     @property
     def ontarget(self):
-        indicators = self.get_complete_indicators().filter(
+        indicators = self.reporting.filter(
             over_under=0
         )
         return indicators
 
     @property
     def undertarget(self):
-        indicators = self.get_complete_indicators().filter(
+        indicators = self.reporting.filter(
             over_under=-1
         )
         return indicators
 
     @property
     def overtarget(self):
-        indicators = self.get_complete_indicators().filter(
+        indicators = self.reporting.filter(
             over_under=1
         )
         return indicators

--- a/indicators/queries.py
+++ b/indicators/queries.py
@@ -1,0 +1,33 @@
+"""Querymanagers and proxymodels to abstract complex queries on indicator models
+
+"""
+
+from indicators.models import (
+    Indicator,
+    Level
+)
+from django.db import models
+#from django.db.models import Sum, Avg, Subquery, OuterRef, Case, When, Q, F, Max
+
+class NoTargetsIndicatorManager(models.Manager):
+    
+    def period(self, period_name, period_start, period_end):
+        
+        
+    def add_level_name(self, qs):
+        most_recent_level = Level.objects.filter(indicator__id=models.OuterRef('pk')).order_by('-id')
+        return qs.annotate(
+            level_name=models.Subquery(most_recent_level.values('name')[:1])
+        )
+
+    def get_queryset(self):
+        qs = super(NoTargetsIndicatorManager, self).get_queryset()
+        qs = self.add_level_name(qs)
+        return qs
+
+class IPTTIndicator(Indicator):
+    SEPARATOR = '/'
+    class Meta:
+        proxy = True
+        
+    notargets = NoTargetsIndicatorManager()

--- a/indicators/queries.py
+++ b/indicators/queries.py
@@ -4,30 +4,213 @@
 
 from indicators.models import (
     Indicator,
-    Level
+    Level,
+    PeriodicTarget,
+    CollectedData
 )
 from django.db import models
+from django.db.models.functions import Concat
 #from django.db.models import Sum, Avg, Subquery, OuterRef, Case, When, Q, F, Max
 
-class NoTargetsIndicatorManager(models.Manager):
-    
-    def period(self, period_name, period_start, period_end):
-        
-        
-    def add_level_name(self, qs):
-        most_recent_level = Level.objects.filter(indicator__id=models.OuterRef('pk')).order_by('-id')
-        return qs.annotate(
-            level_name=models.Subquery(most_recent_level.values('name')[:1])
+class Round(models.Func):
+    function = 'ROUND'
+    template = '%(function)s(%(expressions)s, 0)'
+
+class IPTTIndicatorQuerySet(models.QuerySet):
+    pass
+
+class IPTTIndicatorManager(models.Manager):
+    def get_lop_target_annotations(self):
+        """generates annotations for LOP target and actual data
+
+        takes into account cumulative/noncumulative and number/percent"""
+        indicator_targets = PeriodicTarget.objects.filter(
+            indicator=models.OuterRef('pk')
         )
+        indicator_data = CollectedData.objects.filter(
+            indicator=models.OuterRef('pk')
+        )
+        lop_target_sum = models.Case(
+            models.When(
+                is_cumulative=False,
+                then=models.Subquery(
+                    indicator_targets.order_by().values(
+                        'indicator_id'
+                    ).annotate(
+                        total=models.Sum('target')
+                    ).values('total'),
+                    output_field=models.FloatField()
+                )
+            ),
+            models.When(
+                is_cumulative=True,
+                then=models.Subquery(
+                    indicator_targets.order_by('-end_date').values('target')[:1],
+                    output_field=models.FloatField()))
+        )
+        lop_actual_sum = models.Case(
+            models.When(
+                unit_of_measure_type=Indicator.PERCENTAGE,
+                then=Round(
+                    models.Subquery(
+                        indicator_data.order_by(
+                            '-date_collected'
+                        ).values('achieved')[:1],
+                        output_field=models.FloatField()
+                        )
+                    )
+                ),
+            default=models.Subquery(
+                indicator_data.order_by().values(
+                    'indicator_id'
+                ).annotate(
+                    total=models.Sum('achieved')
+                ).values('total'),
+                output_field=models.FloatField()
+            )
+        )
+        return {
+            'lop_target_sum': lop_target_sum,
+            'lop_actual_sum': lop_actual_sum,
+        }
+
+    def get_labeling_annotations(self):
+        most_recent_level = Level.objects.filter(indicator__id=models.OuterRef('pk')).order_by('-id')
+        return {
+            'level_name': models.Subquery(most_recent_level.values('name')[:1])
+        }
+
+    def get_queryset(self):
+        annotations = self.get_labeling_annotations()
+        annotations.update(self.get_lop_target_annotations())
+        return super(IPTTIndicatorManager, self).get_queryset().annotate(
+            **annotations
+        )
+
+class NoTargetsIndicatorManager(IPTTIndicatorManager):
+
+    def period(self, period_name, period_start, period_end):
+        return self.get_queryset().period(period_name, period_start, period_end)
 
     def get_queryset(self):
         qs = super(NoTargetsIndicatorManager, self).get_queryset()
-        qs = self.add_level_name(qs)
+        return qs
+
+
+class WithTargetsIndicatorManager(IPTTIndicatorManager):
+    """Manager for Indicator with PeriodicTargets and CollectedData
+
+    automatically annotates for lop target and actual lop sum of collected data
+    also can self-annotate for periodic target and actual sum
+    returns % met for the above"""
+
+    def get_target_prefetch(self):
+        # inner query to apply target_id to data collected within target range
+        target_inner_query = PeriodicTarget.objects.filter(
+            indicator_id=models.OuterRef('indicator_id'),
+            start_date__lte=models.OuterRef('date_collected'),
+            end_date__gte=models.OuterRef('date_collected')
+        ).order_by().values('id')[:1]
+        # inner query to collect data annotated by target_id
+        data_with_periods_non_cumulative = CollectedData.objects.filter(
+            indicator_id=models.OuterRef('indicator_id')
+        ).annotate(
+            target_id=models.Subquery(target_inner_query)
+        ).filter(
+            target_id=models.OuterRef('id')
+        ).order_by().values('target_id')
+        data_with_periods_cumulative = CollectedData.objects.filter(
+            indicator_id=models.OuterRef('indicator_id'),
+            date_collected__lte=models.OuterRef('end_date')
+        ).order_by().values('indicator_id')
+        # targets with data sums attached
+        targets = PeriodicTarget.objects.annotate(
+            data_sum=models.Case(
+                models.When(
+                    indicator__unit_of_measure_type=Indicator.PERCENTAGE,
+                    then=models.Subquery(
+                        data_with_periods_non_cumulative.order_by(
+                            '-date_collected'
+                            ).values('achieved')[:1],
+                        output_field=models.FloatField()
+                    )
+                ),
+                models.When(
+                    indicator__is_cumulative=True,
+                    then=models.Subquery(
+                        data_with_periods_cumulative.annotate(
+                            total=models.Sum('achieved')
+                        ).values('total'),
+                        output_field=models.FloatField()
+                    )
+                ),
+                default=models.Subquery(
+                    data_with_periods_non_cumulative.annotate(
+                        total=models.Sum('achieved')
+                    ).values('total'),
+                    output_field=models.FloatField()
+                )
+            )
+        ).annotate(
+            met_real=models.ExpressionWrapper(
+                models.F('data_sum')/models.F('target'),
+                output_field=models.FloatField()
+            ),
+            met=models.ExpressionWrapper(
+                Concat(Round(models.F('data_sum')*100/models.F('target')), models.Value("%")),
+                output_field=models.CharField()
+            )
+        ).annotate(
+            within_target_range=models.Case(
+                models.When(
+                    met_real__gt=1.15,
+                    then=models.Case(
+                        models.When(
+                            indicator__direction_of_change=Indicator.DIRECTION_OF_CHANGE_NEGATIVE,
+                            then=models.Value(-1)
+                        ),
+                        default=models.Value(1)
+                    )
+                ),
+                models.When(
+                    met_real__lt=0.85,
+                    then=models.Case(
+                        models.When(
+                            indicator__direction_of_change=Indicator.DIRECTION_OF_CHANGE_NEGATIVE,
+                            then=models.Value(1)
+                        ),
+                        default=models.Value(-1)
+                    )
+                ),
+                models.When(
+                    met_real__isnull=True,
+                    then=models.Value(None)
+                ),
+                default=models.Value(0),
+                output_field=models.IntegerField()
+            )
+        )
+        prefetch = models.Prefetch(
+            'periodictargets',
+            queryset=targets,
+            to_attr='data_targets'
+        )
+        return prefetch
+
+    def get_queryset(self):
+        qs = super(WithTargetsIndicatorManager, self).get_queryset().prefetch_related(
+            self.get_target_prefetch()
+        )
         return qs
 
 class IPTTIndicator(Indicator):
-    SEPARATOR = '/'
+    SEPARATOR = '/' # this is used by CSV output as a default joiner for multiple values
     class Meta:
         proxy = True
-        
+
     notargets = NoTargetsIndicatorManager()
+    withtargets = WithTargetsIndicatorManager()
+
+    @property
+    def lop_met_target(self):
+        return str(int(round(float(self.lop_actual_sum)*100/self.lop_target_sum))) + "%"

--- a/indicators/tests/test_indicators.py
+++ b/indicators/tests/test_indicators.py
@@ -52,6 +52,7 @@ class IndicatorTestCase(TestCase):
         self.indicator.save()
         data = {
             "program": self.program.id, "level": "1", "number": "1.1.2",
+            'program2': self.program.id,
             "indicator_type": "1",
             "unit_of_measure": "count", "unit_of_measure_type": "2",
             "lop_target": "44", "direction_of_change": "1", "baseline": "10",

--- a/indicators/tests/test_iptt_csv_report.py
+++ b/indicators/tests/test_iptt_csv_report.py
@@ -3,6 +3,7 @@
 url: /indicators/iptt_csv/<program_id>/<reporttype>
 """
 
+import unittest
 from datetime import datetime, timedelta
 from StringIO import StringIO
 import csv
@@ -38,7 +39,7 @@ class CSVTestBase(test.TestCase):
             {v: c for c, v in enumerate(self.fields)}[field]
         ]
 
-
+@unittest.skip("Specs changing on CSV file, tests paused")
 class TestCSVEndpointGeneratesCSVFile(CSVTestBase):
     header_row = ['Program:', 'program_name']
 
@@ -128,7 +129,7 @@ class CSVIndicatorTestBase(CSVTestBase):
         body = [row for row in reader]
         return headers, body
 
-
+@unittest.skip("Specs changing on CSV file, tests paused")
 class TestCSVEndPointIndicatorsAccurate(CSVIndicatorTestBase):
     # to do: test collected data points
 
@@ -218,6 +219,7 @@ class TestCSVEndPointIndicatorsAccurate(CSVIndicatorTestBase):
             self.assert_msg("disaggregations should combine with \"/\" joiner, got {0}".format(
                 self.get_field('disaggregations', indicator_rows[0]))))
 
+@unittest.skip("Specs changing on CSV file, tests paused")
 class TestCSVTotals(CSVIndicatorTestBase):
     def setUp(self):
         super(TestCSVTotals, self).setUp()

--- a/indicators/tests/test_iptt_csv_report.py
+++ b/indicators/tests/test_iptt_csv_report.py
@@ -3,20 +3,45 @@
 url: /indicators/iptt_csv/<program_id>/
 """
 
-from factories.workflow_models import ProgramFactory
-from django import test
+from datetime import datetime, timedelta
 from StringIO import StringIO
 import csv
+from factories.workflow_models import ProgramFactory, SectorFactory
+from factories.indicators_models import (
+    IndicatorFactory,
+    DefinedIndicatorFactory,
+    LevelFactory,
+    DisaggregationTypeFactory,
+    IndicatorTypeFactory,
+    CollectedDataFactory
+    )
+from django import test
 
-class TestCSVEndpointGeneratesCSVFile(test.TestCase):
+class CSVTestBase(test.TestCase):
     url = '/indicators/iptt_csv/{0}/'
+    fields = ['id', 'number', 'name', 'level', 'indicator_type', 'source', 'sector',
+              'definition', 'justification', 'disaggregation', 'unit_of_measure', 'get_unit_of_measure_type',
+              'baseline', 'lop_target', 'get_target_frequency_label', 'means_of_verification',
+              'data_collection_method', 'data_collection_frequency']
+    relation_fields = [3, 4, 9]
+    data_fields = ['lop_sum', 'lop_target', 'lop_met']
+
     def setUp(self):
         self.client = test.Client()
-        self.program = ProgramFactory()
+        self.program = ProgramFactory(reporting_period_start=datetime.strptime('2017-01-01', '%Y-%m-%d'),
+                                      reporting_period_end=datetime.strptime('2017-12-31', '%Y-%m-%d'))
         self.url = self.url.format(self.program.id)
 
     def tearDown(self):
         self.program.delete()
+
+
+class TestCSVEndpointGeneratesCSVFile(CSVTestBase):
+    header_row = ['Program:', 'program_name']
+
+    def setUp(self):
+        super(TestCSVEndpointGeneratesCSVFile, self).setUp()
+        self.header_row[1] = self.program.name
 
     def test_endpoint_exists(self):
         response = self.client.get(self.url)
@@ -34,12 +59,196 @@ class TestCSVEndpointGeneratesCSVFile(test.TestCase):
         self.assertGreater(len(header_row), 1,
                            "expected more than 1 cell in a csv file, got:\n {0}".format(
                                response.content))
-        for c, value in enumerate(['Program:', self.program.name]):
+        for c, value in enumerate(self.header_row):
             self.assertEqual(header_row[c], value,
                              "expected header row 1 cell {0} to be {1}, got {2}".format(
-                                c, value, header_row[c]))
+                                 c, value, header_row[c]))
         subheader_row = response_csv.next()
-        for c, value in enumerate(["id", "name"]):
+        for c, value in enumerate(self.fields):
+            value = value[4:] if value[:4] == 'get_' else value
+            value = value[:-6] if value[-6:] == '_label' else value
             self.assertEqual(subheader_row[c], value,
                              "expected subhead row 2 cell {0} to be {1}, got {2}".format(
-                                c, value, subheader_row[c]))
+                                 c, value, subheader_row[c]))
+
+class CSVIndicatorTestBase(CSVTestBase):
+    def setUp(self):
+        super(CSVIndicatorTestBase, self).setUp()
+        self.sectors = [SectorFactory(),]
+        self.levels = [LevelFactory(),]
+        self.disaggregations = [DisaggregationTypeFactory(),]
+        self.indicatortypes = [IndicatorTypeFactory(),]
+        self.indicators = []
+        self.response = None
+
+    def tearDown(self):
+        for indicator in self.indicators:
+            indicator.delete()
+        for sector in self.sectors:
+            sector.delete()
+        for level in self.levels:
+            level.delete()
+        for disag in self.disaggregations:
+            disag.delete()
+        for indicatortype in self.indicatortypes:
+            indicatortype.delete()
+        super(CSVIndicatorTestBase, self).tearDown()
+
+    def assert_msg(self, msg):
+        if self.response:
+            return "Unformatted CSV Response:\n{0}:\n{1}".format(self.response, msg)
+        return msg
+
+    def get_indicator(self, sector=0, level=0, disaggregation=0,
+                      indicatortype=0):
+        indicator = DefinedIndicatorFactory(sector=self.sectors[sector])
+        indicator.level.add(self.levels[level])
+        indicator.disaggregation.add(self.disaggregations[disaggregation])
+        indicator.indicator_type.add(self.indicatortypes[indicatortype])
+        indicator.save()
+        return indicator
+
+    def add_indicator(self, *args, **kwargs):
+        indicator = self.get_indicator(*args, **kwargs)
+        indicator.program.add(self.program)
+        self.indicators.append(indicator)
+        return indicator
+
+    def get_rows(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200,
+                         "Expected a 200 OK at url {0}, got {1}".format(
+                             self.url, response.status_code))
+        self.response = response.content
+        reader = csv.reader(StringIO(response.content))
+        headers = [reader.next(), reader.next()]
+        body = [row for row in reader]
+        return headers, body
+
+
+class TestCSVEndPointIndicatorsAccurate(CSVIndicatorTestBase):
+    # to do: test collected data points
+
+    def compare_indicator(self, indicator, row):
+        for c, field in enumerate(self.fields):
+            self.assertGreater(len(row), c,
+                               self.assert_msg("row should have at least {0} fields, has {1}".format(
+                                   c+1, len(row))))
+            value = getattr(indicator, field)
+            value = value.first() if c in self.relation_fields else value
+            value = str(value) if value is not None else "N/A"
+            self.assertEqual(value, str(row[c]),
+                             self.assert_msg("cell {0} should be {1} field with value {2}, got value {3}".format(
+                                 c, field, value, row[c])))
+        return True
+
+    def test_row_counts(self):
+        self.add_indicator()
+        _, indicator_rows = self.get_rows()
+        self.assertEqual(len(indicator_rows), 1,
+                         self.assert_msg("One indicator added, should have one row returned"))
+        self.add_indicator()
+        _, indicator_rows = self.get_rows()
+        self.assertEqual(len(indicator_rows), 2,
+                         self.assert_msg("Two indicators added, should have two rows returned"))
+        self.add_indicator()
+        _, indicator_rows = self.get_rows()
+        self.assertEqual(len(indicator_rows), 3,
+                         self.assert_msg("Three indicators added, should have three rows returned"))
+        self.indicators.pop(1).delete()
+        _, indicator_rows = self.get_rows()
+        self.assertEqual(len(indicator_rows), 2,
+                         self.assert_msg("Three indicators added, one removed, should have two rows returned"))
+
+    def test_indicator_global_info(self):
+        self.add_indicator()
+        _, indicator_rows = self.get_rows()
+        self.assertTrue(self.compare_indicator(self.indicators[0], indicator_rows[0]))
+
+    def test_indicator_info_with_blanks(self):
+        indicator = self.add_indicator()
+        indicator.level.remove(self.levels[0])
+        indicator.means_of_verification = None
+        indicator.save()
+        _, indicator_rows = self.get_rows()
+        self.assertTrue(self.compare_indicator(self.indicators[0], indicator_rows[0]))
+        self.assertEqual(indicator_rows[0][3], "N/A",
+                         self.assert_msg("removed all levels, level should show N/A, got {0}".format(
+                             indicator_rows[0][3])))
+        self.assertEqual(indicator_rows[0][15], "N/A",
+                         self.assert_msg("removed means of verification, should show N/A, got {0}".format(
+                             indicator_rows[0][15])))
+
+    def test_two_indicators_global_info(self):
+        self.add_indicator()
+        self.add_indicator()
+        _, indicator_rows = self.get_rows()
+        self.assertTrue(self.compare_indicator(self.indicators[0], indicator_rows[0]))
+        self.assertTrue(self.compare_indicator(self.indicators[1], indicator_rows[1]))
+
+    def test_two_indicators_different_relations(self):
+        self.add_indicator()
+        self.sectors.append(SectorFactory())
+        self.add_indicator(sector=1)
+        _, indicator_rows = self.get_rows()
+        self.assertNotEqual(self.sectors[0].sector, self.sectors[1].sector,
+                            "test invalid if sectors have same name")
+        self.assertNotEqual(indicator_rows[0][6], indicator_rows[1][6],
+                            self.assert_msg("sectors have different names, cells must be different also"))
+        self.assertEqual(indicator_rows[0][6], self.sectors[0].sector,
+                         self.assert_msg("different levels should show differently, got {0} instead of {1}".format(
+                             indicator_rows[0][6], self.sectors[0].sector)))
+        self.assertEqual(indicator_rows[1][6], self.sectors[1].sector,
+                         self.assert_msg("different levels should show differently, got {0} instead of {1}".format(
+                             indicator_rows[1][6], self.sectors[1].sector)))
+
+    def test_multiple_disaggregation_types(self):
+        indicator = self.add_indicator()
+        self.disaggregations.append(DisaggregationTypeFactory())
+        indicator.disaggregation.add(self.disaggregations[1])
+        indicator.save()
+        _, indicator_rows = self.get_rows()
+        self.assertEqual(
+            indicator_rows[0][9],
+            self.disaggregations[0].disaggregation_type + "/" + self.disaggregations[1].disaggregation_type,
+            self.assert_msg("disaggregations should combine with \"/\" joiner, got {0}".format(
+                indicator_rows[0][9])))
+
+class TestCSVTotals(CSVIndicatorTestBase):
+    def setUp(self):
+        super(TestCSVTotals, self).setUp()
+        self.datapoints = []
+
+    def tearDown(self):
+        super(TestCSVTotals, self).tearDown()
+        for datapoint in self.datapoints:
+            datapoint.delete()
+
+    def add_data(self, value, collect_date=None, indicator=None):
+        if indicator is None:
+            indicator = self.add_indicator() if not self.indicators else self.indicators[0]
+        collect_date = (
+            self.program.reporting_period_start + timedelta(days=1) if collect_date is None else collect_date
+            )
+        self.datapoints.append(
+            CollectedDataFactory(indicator=indicator, date_collected=collect_date, achieved=value)
+        )
+
+    def get_data_rows(self):
+        _, indicator_rows = self.get_rows()
+        return [row[18:] for row in indicator_rows]
+
+    def test_header_fields(self):
+        header_rows, _ = self.get_rows()
+        for c, value in enumerate(self.data_fields):
+            self.assertEqual(header_rows[1][c+18], value,
+                             self.assert_msg("subhead row cell {0} should have value {1} got {2}".format(
+                                 c+18, value, header_rows[1][c+18])))
+
+    def test_lop_sum(self):
+        self.add_indicator()
+        self.add_data(10)
+        data_row = self.get_data_rows()[0]
+        self.assertEqual(data_row[0], 10,
+                         self.assert_msg("one data point value 10 should yield a total of 10, got {0}".format(
+                            data_row[0])))

--- a/indicators/tests/test_iptt_csv_report.py
+++ b/indicators/tests/test_iptt_csv_report.py
@@ -1,0 +1,45 @@
+""" Functional tests for the CSV generation file for Palantir import
+
+url: /indicators/iptt_csv/<program_id>/
+"""
+
+from factories.workflow_models import ProgramFactory
+from django import test
+from StringIO import StringIO
+import csv
+
+class TestCSVEndpointGeneratesCSVFile(test.TestCase):
+    url = '/indicators/iptt_csv/{0}/'
+    def setUp(self):
+        self.client = test.Client()
+        self.program = ProgramFactory()
+        self.url = self.url.format(self.program.id)
+
+    def tearDown(self):
+        self.program.delete()
+
+    def test_endpoint_exists(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200,
+                         "Expected a 200 OK at url {0}, got {1}".format(
+                             self.url, response.status_code))
+
+    def test_endpoint_returns_csv(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response['Content-Type'], "text/csv",
+                         "expected a text/csv response,at url {0}, got {1}".format(
+                             self.url, response['Content-Type']))
+        response_csv = csv.reader(StringIO(response.content))
+        header_row = response_csv.next()
+        self.assertGreater(len(header_row), 1,
+                           "expected more than 1 cell in a csv file, got:\n {0}".format(
+                               response.content))
+        for c, value in enumerate(['Program:', self.program.name]):
+            self.assertEqual(header_row[c], value,
+                             "expected header row 1 cell {0} to be {1}, got {2}".format(
+                                c, value, header_row[c]))
+        subheader_row = response_csv.next()
+        for c, value in enumerate(["id", "name"]):
+            self.assertEqual(subheader_row[c], value,
+                             "expected subhead row 2 cell {0} to be {1}, got {2}".format(
+                                c, value, subheader_row[c]))

--- a/indicators/tests/test_program_indicator_queries.py
+++ b/indicators/tests/test_program_indicator_queries.py
@@ -11,13 +11,6 @@ Decisions:
         tested in test_time_aware_iptt_queries
       
 
-1. For all completed target periods to date, what is the target value?
-  1.1. Calculation takes into account cumulative vs non-cumulative and # vs %
-  2. For all completed target periods to date, what is the actual value?
-  2.1. Calculation takes into account cumulative vs non-cumulative and # vs %
-  3. For all completed target periods to date, what is the percentage variance of the actual value from the target value?
-  4. Which indicators are INSIDE the plus or minus 15% variance range?
-  3.1. How many indicators?
   3.2. What percentage of indicators?
   4. Which indicators are ABOVE the 15% variance range?
   4.1. How many indicators?
@@ -25,20 +18,18 @@ Decisions:
   5. Which indicators are BELOW the 15% variance range?
   5.1. How many indicators?
   5.2. What percentage of indicators?
-  
 """
 
-
-from django import test, db
-from django.conf import settings
 import datetime
-import unittest
+from indicators.models import Indicator, PeriodicTarget
+from indicators.queries import ProgramWithMetrics, IPTTIndicator
 from factories import (
     workflow_models as w_factories,
     indicators_models as i_factories
     )
-from indicators.models import Indicator, PeriodicTarget
-from indicators.queries import ProgramWithMetrics, IPTTIndicator
+from django import test
+from django.conf import settings
+from django.db import connection
 
 class TestCollectionCorrect(test.TestCase):
     def setUp(self):
@@ -207,47 +198,292 @@ class TestCollectionCorrect(test.TestCase):
         )
 
 
-    @unittest.skip('not implemented')
     def test_event_sums_all_targets_using_customsort(self):
-        self.fail('not implemented')
-
-    @unittest.skip('not implemented')
-    def test_time_aware_sums_targets(self):
-        self.fail('not implemented')
-
-class TestDataCollectionCorrect(test.TestCase):
-    def setUp(self):
-        self.program = w_factories.ProgramFactory()
-        self.indicator = i_factories.IndicatorFactory()
-        self.indicator.program.add(self.program)
+        self.indicator.target_frequency = Indicator.EVENT
         self.indicator.save()
-        self.targets = []
+        target_1 = i_factories.PeriodicTargetFactory(
+            indicator=self.indicator,
+            target=500,
+            period="event 1",
+            customsort=0
+        )
+        target_2 = i_factories.PeriodicTargetFactory(
+            indicator=self.indicator,
+            target=800,
+            period="event 2",
+            customsort=1
+        )
+        self.targets.extend([target_1, target_2])
+        data_1 = i_factories.CollectedDataFactory(
+            indicator=self.indicator,
+            periodic_target=target_1,
+            achieved=350,
+            date_collected=self.program.reporting_period_start + datetime.timedelta(days=1)
+        )
+        self.data.append(data_1)
+        indicator = IPTTIndicator.withtargets.get(pk=self.indicator.id)
+        # both have data, defaults to non_cumulative, so should show sum of both targets:
+        self.assertEqual(
+            indicator.lop_target_sum, 500,
+            "should not sum targets (no data for second target) expecting 500, got {0}".format(
+                indicator.lop_target_sum)
+        )
+        self.assertEqual(
+            indicator.lop_actual_sum, 350,
+            "should show only data, 350 got {0}".format(indicator.lop_actual_sum)
+        )
+        self.assertEqual(
+            indicator.over_under, -1,
+            "should show under (350/500), got {0}".format(indicator.over_under)
+        )
+        self.assertEqual(
+            ProgramWithMetrics.objects.get(pk=self.program.id).undertarget.count(),
+            1,
+            "should show 1 undertarget indicator"
+        )
+        data_2 = i_factories.CollectedDataFactory(
+            indicator=self.indicator,
+            periodic_target=target_2,
+            achieved=950,
+            date_collected=self.program.reporting_period_start + datetime.timedelta(days=20)
+        )
+        self.data.append(data_2)
+        indicator = IPTTIndicator.withtargets.get(pk=self.indicator.id)
+        self.assertEqual(
+            indicator.lop_target_sum, 1300,
+            "expected sum of targets (both have data) 1300, got {0}".format(indicator.lop_target_sum)
+        )
+        self.assertEqual(
+            indicator.lop_actual_sum, 1300,
+            "expecting sum of data 1300, got {0}".format(indicator.lop_actual_sum)
+        )
+        self.assertEqual(
+            indicator.over_under, 0,
+            "should show on target (over under 0, 1300/1300), got {0}".format(indicator.over_under)
+        )
+        self.assertEqual(
+            ProgramWithMetrics.objects.get(pk=self.program.id).ontarget.count(), 1,
+            "should show 1 on target indicator"
+        )
+        self.indicator.is_cumulative = True
+        self.indicator.save()
+        indicator = IPTTIndicator.withtargets.get(pk=self.indicator.id)
+        self.assertEqual(
+            indicator.lop_target_sum, 800,
+            "expected most recent target for non-cumulative indicator 800, got {0}".format(indicator.lop_target_sum)
+        )
+        self.assertEqual(
+            ProgramWithMetrics.objects.get(pk=self.program.id).overtarget.count(), 1,
+            "exepcted 1 overtarget indicator"
+        )
+
+class TestProgramReportingingCounts (test.TestCase):
+    def setUp(self):
+        settings.DEBUG = True
+        self.program = w_factories.ProgramFactory(
+            reporting_period_start=datetime.date.today()-datetime.timedelta(days=365),
+            reporting_period_end=datetime.date.today()-datetime.timedelta(days=1)
+        )
+        self.indicators = []
         self.data = []
+        self.targets = []
+        self.indicators.extend(self.get_on_target_indicators())
+        self.indicators.extend(self.get_undertarget_indicators())
+        self.indicators.extend(self.get_overtarget_indicators())
+        self.indicators.extend(self.get_nonreporting_indicators())
+        baseline = len(connection.queries)
+        self.reporting_program = ProgramWithMetrics.objects.get(pk=self.program.id)
+        self.fetch_queries = len(connection.queries) - baseline
 
     def tearDown(self):
         for datum in self.data:
             datum.delete()
         for target in self.targets:
             target.delete()
-        self.indicator.delete()
+        for indicator in self.indicators:
+            indicator.delete()
         self.program.delete()
 
-    @unittest.skip('not implemented')
-    def test_lop_target_sums_all_data(self):
-        self.fail('not implemented')
+    def get_base_indicator(self):
+        indicator = i_factories.IndicatorFactory()
+        indicator.program.add(self.program)
+        indicator.save()
+        return indicator
 
-    @unittest.skip('not implemented')
-    def test_midend_sums_data_with_both_data(self):
-        self.fail('not implemented')
+    def get_base_data(self, indicator, target=None):
+        data = i_factories.CollectedDataFactory(
+            indicator=indicator,
+            periodic_target=target,
+            date_collected=self.program.reporting_period_start + datetime.timedelta(days=10)
+        )
+        return data
 
-    @unittest.skip('not implemented')
-    def test_midend_sums_midend_if_no_endline_data(self):
-        self.fail('not implemented')
+    def get_on_target_indicators(self):
+        # lop indicator on target to lop target value
+        lop_indicator = self.get_base_indicator()
+        lop_indicator.target_frequency = Indicator.LOP
+        lop_indicator.lop_target = 10000
+        lop_indicator.is_cumulative = False
+        lop_indicator.unit_of_measure_type = Indicator.NUMBER
+        lop_indicator.save()
+        lop_data = self.get_base_data(lop_indicator)
+        lop_data.achieved = 10000
+        lop_data.save()
+        self.data.append(lop_data)
+        # semi annual indicator with target and valid data
+        time_indicator = self.get_base_indicator()
+        time_indicator.target_frequency = Indicator.SEMI_ANNUAL
+        time_indicator.is_cumulative = True
+        time_indicator.unit_of_measure_type = Indicator.NUMBER
+        time_indicator.save()
+        start_date = self.program.reporting_period_start
+        mid_date = datetime.date(
+            start_date.year + 1 if start_date.month > 6 else start_date.year,
+            start_date.month - 6 if start_date.month > 6 else start_date.month + 6,
+            start_date.day)
+        time_target_1 = i_factories.PeriodicTargetFactory(
+            indicator=time_indicator,
+            target=400,
+            start_date=start_date,
+            end_date=mid_date - datetime.timedelta(days=1)
+        )
+        time_target_2 = i_factories.PeriodicTargetFactory(
+            indicator=time_indicator,
+            target=600,
+            start_date=mid_date,
+            end_date=self.program.reporting_period_end
+        )
+        self.targets.extend([time_target_1, time_target_2])
+        data_1 = i_factories.CollectedDataFactory(
+            indicator=time_indicator,
+            periodic_target=time_target_1,
+            date_collected=time_target_1.start_date + datetime.timedelta(days=2),
+            achieved=200
+        )
+        data_2 = i_factories.CollectedDataFactory(
+            indicator=time_indicator,
+            periodic_target=time_target_2,
+            date_collected=time_target_2.start_date + datetime.timedelta(days=2),
+            achieved=600
+        )
+        self.data.extend([data_1, data_2])
+        return [lop_indicator, time_indicator]
 
-    @unittest.skip('not implemented')
-    def test_event_sums_all_data_using_date_collected(self):
-        self.fail('not implemented')
+    def get_undertarget_indicators(self):
+        # event indicator (percent) with less than 85% of the target % hit
+        event_indicator = self.get_base_indicator()
+        event_indicator.target_frequency = Indicator.EVENT
+        event_indicator.is_cumulative = False
+        event_indicator.unit_of_measure_type = Indicator.PERCENTAGE
+        event_indicator.save()
+        event_target = i_factories.PeriodicTargetFactory(
+            indicator=event_indicator,
+            target=75,
+            customsort=0,
+            period="event 1"
+        )
+        self.targets.append(event_target)
+        event_data = self.get_base_data(indicator=event_indicator, target=event_target)
+        event_data.achieved = 60
+        event_data.save()
+        self.data.append(event_data)
+        return [event_indicator]
 
-    @unittest.skip('not implemented')
-    def test_time_aware_sums_targets(self):
-        self.fail('not implemented')
+    def get_overtarget_indicators(self):
+        # lop indicator with 120/100 data
+        lop_indicator = self.get_base_indicator()
+        lop_indicator.target_frequency = Indicator.LOP
+        lop_indicator.is_cumulative = False
+        lop_indicator.lop_target = 100
+        lop_indicator.save()
+        lop_data = self.get_base_data(lop_indicator)
+        lop_data.achieved = 120
+        lop_data.save()
+        self.data.append(lop_data)
+        # negative direction of change so under data should show as over target
+        neg_indicator = self.get_base_indicator()
+        neg_indicator.target_frequency = Indicator.LOP
+        neg_indicator.direction_of_change = Indicator.DIRECTION_OF_CHANGE_NEGATIVE
+        neg_indicator.lop_target = 800
+        neg_indicator.save()
+        neg_data = self.get_base_data(neg_indicator)
+        neg_data.achieved = 600
+        neg_data.save()
+        self.data.append(neg_data)
+        # mid end indicator _cumulative_ should check against end target only
+        midend_indicator = self.get_base_indicator()
+        midend_indicator.target_frequency = Indicator.MID_END
+        midend_indicator.is_cumulative = True
+        midend_indicator.save()
+        mid_target = i_factories.PeriodicTargetFactory(
+            indicator=midend_indicator,
+            period=PeriodicTarget.MIDLINE,
+            customsort=0,
+            target=500
+        )
+        end_target = i_factories.PeriodicTargetFactory(
+            indicator=midend_indicator,
+            period=PeriodicTarget.ENDLINE,
+            customsort=1,
+            target=800
+        )
+        self.targets.extend([mid_target, end_target])
+        mid_data_1 = self.get_base_data(midend_indicator, mid_target)
+        mid_data_1.achieved = 200
+        mid_data_1.save()
+        mid_data_2 = self.get_base_data(midend_indicator, mid_target)
+        mid_data_2.achieved = 200
+        mid_data_2.save()
+        mid_data_3 = self.get_base_data(midend_indicator, end_target)
+        mid_data_3.achieved = 250
+        mid_data_3.save()
+        mid_data_4 = self.get_base_data(midend_indicator, end_target)
+        mid_data_4.achieved = 250
+        mid_data_4.save()
+        self.data.extend([mid_data_1, mid_data_2, mid_data_3, mid_data_4])
+        return [lop_indicator, neg_indicator, midend_indicator]
+
+    def get_nonreporting_indicators(self):
+        event_indicator = self.get_base_indicator()
+        event_indicator.target_frequency = Indicator.EVENT
+        event_indicator.save()
+        event_target = i_factories.PeriodicTargetFactory(
+            indicator=event_indicator,
+            target=400,
+            customsort=0,
+            period="event 1"
+        )
+        self.targets.append(event_target)
+        return [event_indicator]
+
+    def test_counts(self):
+        baseline = len(connection.queries)
+        ontarget_count = self.reporting_program.ontarget.count()
+        ontarget_queries = len(connection.queries) - baseline
+        baseline = len(connection.queries)
+        overtarget_count = self.reporting_program.overtarget.count()
+        overtarget_queries = len(connection.queries) - baseline
+        baseline = len(connection.queries)
+        undertarget_count = self.reporting_program.undertarget.count()
+        undertarget_queries = len(connection.queries) - baseline
+        baseline = len(connection.queries)
+        nonreporting_count = self.reporting_program.nonreporting.count()
+        nonreporting_queries = len(connection.queries) - baseline
+        baseline = len(connection.queries)
+        self.assertEqual(
+            ontarget_count, 2, "expected 2 ontarget, got {0}".format(ontarget_count)
+        )
+        self.assertEqual(
+            overtarget_count, 3, "expected 3 overtarget, got {0}".format(overtarget_count)
+        )
+        self.assertEqual(
+            undertarget_count, 1, "expected 1 undertarget, got {0}".format(undertarget_count)
+        )
+        self.assertEqual(
+            nonreporting_count, 1, "expected 1 nonreporting, got {0}".format(nonreporting_count)
+        )
+        # query count tests:
+        for c, query_count in enumerate([self.fetch_queries, ontarget_queries, overtarget_queries,
+                                         undertarget_queries, nonreporting_queries]):
+            self.assertEqual(query_count, 1, "expected 1 query for #{0} got {1}".format(c, query_count))
+            

--- a/indicators/tests/test_program_indicator_queries.py
+++ b/indicators/tests/test_program_indicator_queries.py
@@ -1,0 +1,253 @@
+"""Tests for the Mangosteen program queries (indicator on target/completion reporting)
+
+Ticket: https://github.com/mercycorps/TolaActivity/issues/463
+Decisions:
+    which targets/data do we count:
+        LOP - lop_target / all data (sum)
+        MID_END - whichever targets have data, all data associated to those targets
+        EVENT - all data and all targets
+        TIME-AWARE - all targets which have completed, all data during those periods
+    how do we sum:
+        tested in test_time_aware_iptt_queries
+      
+
+1. For all completed target periods to date, what is the target value?
+  1.1. Calculation takes into account cumulative vs non-cumulative and # vs %
+  2. For all completed target periods to date, what is the actual value?
+  2.1. Calculation takes into account cumulative vs non-cumulative and # vs %
+  3. For all completed target periods to date, what is the percentage variance of the actual value from the target value?
+  4. Which indicators are INSIDE the plus or minus 15% variance range?
+  3.1. How many indicators?
+  3.2. What percentage of indicators?
+  4. Which indicators are ABOVE the 15% variance range?
+  4.1. How many indicators?
+  4.2. What percentage of indicators?
+  5. Which indicators are BELOW the 15% variance range?
+  5.1. How many indicators?
+  5.2. What percentage of indicators?
+  
+"""
+
+
+from django import test, db
+from django.conf import settings
+import datetime
+import unittest
+from factories import (
+    workflow_models as w_factories,
+    indicators_models as i_factories
+    )
+from indicators.models import Indicator, PeriodicTarget
+from indicators.queries import ProgramWithMetrics, IPTTIndicator
+
+class TestCollectionCorrect(test.TestCase):
+    def setUp(self):
+        self.program = w_factories.ProgramFactory(
+            reporting_period_start=datetime.date(2016, 10, 1),
+            reporting_period_end=datetime.date(2017, 9, 30)
+        )
+        self.indicator = i_factories.IndicatorFactory()
+        self.indicator.program.add(self.program)
+        self.indicator.save()
+        self.targets = []
+        self.data = []
+
+    def tearDown(self):
+        for datum in self.data:
+            datum.delete()
+        for target in self.targets:
+            target.delete()
+        self.indicator.delete()
+        self.program.delete()
+
+    def test_midend_target_sums_midend_with_both_data(self):
+        self.indicator.target_frequency = Indicator.MID_END
+        self.indicator.save()
+        mid_target = i_factories.PeriodicTargetFactory(
+            indicator=self.indicator,
+            target=500,
+            period=PeriodicTarget.MIDLINE,
+            customsort=0
+        )
+        end_target = i_factories.PeriodicTargetFactory(
+            indicator=self.indicator,
+            target=800,
+            period=PeriodicTarget.ENDLINE,
+            customsort=1
+        )
+        self.targets.extend([mid_target, end_target])
+        mid_data = i_factories.CollectedDataFactory(
+            indicator=self.indicator,
+            periodic_target=mid_target,
+            achieved=350,
+            date_collected=self.program.reporting_period_start + datetime.timedelta(days=1)
+        )
+        end_data = i_factories.CollectedDataFactory(
+            indicator=self.indicator,
+            periodic_target=end_target,
+            achieved=950,
+            date_collected=self.program.reporting_period_start + datetime.timedelta(days=10)
+        )
+        self.data.extend([mid_data, end_data])
+        indicator = IPTTIndicator.withtargets.get(pk=self.indicator.id)
+        # both have data, defaults to non_cumulative, so should show sum of both targets:
+        self.assertEqual(
+            indicator.lop_target_sum, 1300,
+            "should sum both targets 500 and 800 to get 1300, got {0}".format(indicator.lop_target_sum)
+        )
+        # both have data and targets, defaults to non_cumulative, should show sum of both data:
+        self.assertEqual(
+            indicator.lop_actual_sum, 1300,
+            "should sum both data 350 and 950 to get 1300, got {0}".format(indicator.lop_actual_sum)
+        )
+        self.assertEqual(
+            indicator.over_under, 0,
+            "should show overunder as 0 (in range), got {0}".format(indicator.over_under)
+        )
+        self.assertEqual(
+            ProgramWithMetrics.objects.get(pk=self.program.id).ontarget.count(),
+            1,
+            "should show 1 ontarget indicator"
+        )
+        self.indicator.is_cumulative = True
+        self.indicator.save()
+        indicator = IPTTIndicator.withtargets.get(pk=self.indicator.id)
+        # both have data, set to cumulative, so should show latest (endline) target:
+        self.assertEqual(
+            indicator.lop_target_sum, 800,
+            "should show latest target (800), got {0}".format(indicator.lop_target_sum)
+        )
+        # both have data and targets, defaults to non_cumulative, should show sum of both data:
+        self.assertEqual(
+            indicator.lop_actual_sum, 1300,
+            "should show all data (1300), got {0}".format(indicator.lop_actual_sum)
+        )
+        self.assertEqual(
+            indicator.over_under, 1,
+            "should show overunder as 1 (over range), got {0}".format(indicator.over_under)
+        )
+        self.assertEqual(
+            ProgramWithMetrics.objects.get(pk=self.program.id).overtarget.count(),
+            1,
+            "should show 1 overtarget indicator"
+        )
+        self.indicator.direction_of_change = Indicator.DIRECTION_OF_CHANGE_NEGATIVE
+        self.indicator.save()
+        indicator = IPTTIndicator.withtargets.get(pk=self.indicator.id)
+        self.assertEqual(
+            indicator.over_under, -1,
+            "should show overunder as -1 (under range - negative DOC), got {0}".format(indicator.over_under)
+        )
+        self.assertEqual(
+            ProgramWithMetrics.objects.get(pk=self.program.id).undertarget.count(),
+            1,
+            "should show 1 undertarget indicator"
+        )
+
+    def test_midend_doesnt_sum_if_no_endline_data(self):
+        self.indicator.target_frequency = Indicator.MID_END
+        self.indicator.save()
+        mid_target = i_factories.PeriodicTargetFactory(
+            indicator=self.indicator,
+            target=500,
+            period=PeriodicTarget.MIDLINE,
+            customsort=0
+        )
+        end_target = i_factories.PeriodicTargetFactory(
+            indicator=self.indicator,
+            target=800,
+            period=PeriodicTarget.ENDLINE,
+            customsort=1
+        )
+        self.targets.extend([mid_target, end_target])
+        mid_data = i_factories.CollectedDataFactory(
+            indicator=self.indicator,
+            periodic_target=mid_target,
+            achieved=350,
+            date_collected=self.program.reporting_period_start + datetime.timedelta(days=1)
+        )
+        self.data.append(mid_data)
+        indicator = IPTTIndicator.withtargets.get(pk=self.indicator.id)
+        # both have data, defaults to non_cumulative, so should show sum of both targets:
+        self.assertEqual(
+            indicator.lop_target_sum, 500,
+            "should not sum targets (no data for endline) expecting 500, got {0}".format(indicator.lop_target_sum)
+        )
+        self.assertEqual(
+            indicator.lop_actual_sum, 350,
+            "should show only data, 350 got {0}".format(indicator.lop_actual_sum)
+        )
+        self.assertEqual(
+            indicator.over_under, -1,
+            "should show under (350/500), got {0}".format(indicator.over_under)
+        )
+        self.assertEqual(
+            ProgramWithMetrics.objects.get(pk=self.program.id).undertarget.count(),
+            1,
+            "should show 1 undertarget indicator"
+        )
+        self.indicator.direction_of_change = Indicator.DIRECTION_OF_CHANGE_NEGATIVE
+        self.indicator.save()
+        indicator = IPTTIndicator.withtargets.get(pk=self.indicator.id)
+        self.assertEqual(
+            indicator.over_under, 1,
+            "should show over (350/500), got {0}".format(indicator.over_under)
+        )
+        self.assertEqual(
+            ProgramWithMetrics.objects.get(pk=self.program.id).overtarget.count(),
+            1,
+            "should show 1 overtarget indicator"
+        )
+        self.indicator.is_cumulative = True
+        self.indicator.save()
+        indicator = IPTTIndicator.withtargets.get(pk=self.indicator.id)
+        self.assertEqual(
+            indicator.lop_target_sum, 500,
+            "should not take endline target (no data`) expecting 500, got {0}".format(indicator.lop_target_sum)
+        )
+
+
+    @unittest.skip('not implemented')
+    def test_event_sums_all_targets_using_customsort(self):
+        self.fail('not implemented')
+
+    @unittest.skip('not implemented')
+    def test_time_aware_sums_targets(self):
+        self.fail('not implemented')
+
+class TestDataCollectionCorrect(test.TestCase):
+    def setUp(self):
+        self.program = w_factories.ProgramFactory()
+        self.indicator = i_factories.IndicatorFactory()
+        self.indicator.program.add(self.program)
+        self.indicator.save()
+        self.targets = []
+        self.data = []
+
+    def tearDown(self):
+        for datum in self.data:
+            datum.delete()
+        for target in self.targets:
+            target.delete()
+        self.indicator.delete()
+        self.program.delete()
+
+    @unittest.skip('not implemented')
+    def test_lop_target_sums_all_data(self):
+        self.fail('not implemented')
+
+    @unittest.skip('not implemented')
+    def test_midend_sums_data_with_both_data(self):
+        self.fail('not implemented')
+
+    @unittest.skip('not implemented')
+    def test_midend_sums_midend_if_no_endline_data(self):
+        self.fail('not implemented')
+
+    @unittest.skip('not implemented')
+    def test_event_sums_all_data_using_date_collected(self):
+        self.fail('not implemented')
+
+    @unittest.skip('not implemented')
+    def test_time_aware_sums_targets(self):
+        self.fail('not implemented')

--- a/indicators/tests/test_program_indicator_reporting_sort.py
+++ b/indicators/tests/test_program_indicator_reporting_sort.py
@@ -1,0 +1,567 @@
+"""Tests for the Mangosteen program queries (indicator on target/completion reporting)
+
+Ticket: https://github.com/mercycorps/TolaActivity/issues/463
+Cases:
+    Program
+        - open reporting period
+            - LOP indicators should be "incomplete"
+            - time aware indicators should report on most recently completed target
+        - closed reporting period
+            - LOP indicators should report
+            - time aware indicators should report on all targets / sum of targets
+    Indicator
+        - no indicators
+            - all buckets should be empty
+        - one indicator
+            - should be in appropriate bucket
+        - multiple indicators
+            - should be bucketed appropriately
+    Frequency
+        - LOP
+            - should report data against lop_target field
+        - MID_END
+            - should report midline data against midline target, endline data against endline target
+            - should only report against targets for which at least 1 data point exists
+        - EVENT
+            - should report all data against event target
+            - should only report if at least 1 data point collected
+        - time-based
+            - should report on reporting_period_start through most recently completed target period
+    Data
+        - no data
+            - should bucket "incomplete"
+        - one data
+            - should report data point against target
+        - multiple data
+            - should report data sum against target
+    Target
+        - no target
+            - should bucket "incomplete"
+        - one target
+            - should report against target
+        - multiple target
+            - should report against target sums
+    Summation
+        - cumulative
+            - should report latest data point against latest target
+        - non cumulative
+            - should report sum of data points against sum of targets
+    DOC
+        - +
+            - over target = 1, under target = -1
+        - -
+            - over target = -1, under target = 1
+    Measure
+        - Number
+            - noncumulative = add
+        - Percentage
+            - noncumulative = no data (nonsense data)
+
+1. For all completed target periods to date, what is the target value?
+  1.1. Calculation takes into account cumulative vs non-cumulative and # vs %
+  2. For all completed target periods to date, what is the actual value?
+  2.1. Calculation takes into account cumulative vs non-cumulative and # vs %
+  3. For all completed target periods to date, what is the percentage variance of the actual value from the target value?
+  4. Which indicators are INSIDE the plus or minus 15% variance range?
+  3.1. How many indicators?
+  3.2. What percentage of indicators?
+  4. Which indicators are ABOVE the 15% variance range?
+  4.1. How many indicators?
+  4.2. What percentage of indicators?
+  5. Which indicators are BELOW the 15% variance range?
+  5.1. How many indicators?
+  5.2. What percentage of indicators?
+  
+
+Units
+ProgramWithMetrics.reporting.all()
+    - returns a queryset of all indicators which meet criteria to report
+        - LOP indicator in closed program with lop_target
+        - Midline/Endline/Event with set target and 1+ data
+        - Time aware indicator with completed target period and set target and 1+ data
+ProgramWithMetrics.nonreporting.all()
+    - return a queryset of all indicators which do not meet criteria to report
+        - LOP indicator in open program
+        - LOP indicator in closed program with no lop_target
+        - Midline/Endline indicator with no data/target
+        - Event indicator with no data/target
+        - Time aware indicator with no data
+        - Time aware indicator with no target
+        - Time aware indicator with no completed target period
+
+Reporting Indicators Queryset (can assume all indicators here have targets, data, and complete period):
+    .overtarget
+    .undertarget
+    .ontarget
+"""
+
+
+from django import test, db
+from django.conf import settings
+import datetime
+import unittest
+from factories import (
+    workflow_models as w_factories,
+    indicators_models as i_factories
+    )
+from indicators.models import Indicator, PeriodicTarget
+from indicators.queries import ProgramWithMetrics, IPTTIndicator
+
+
+class ReportingIndicatorBase(test.TestCase):
+    TIME_AWARE_FREQUENCIES = [
+        Indicator.ANNUAL,
+        Indicator.SEMI_ANNUAL,
+        Indicator.TRI_ANNUAL,
+        Indicator.QUARTERLY,
+        Indicator.MONTHLY
+    ]
+
+    DATE_FUNCS = {
+        Indicator.ANNUAL: lambda x: datetime.date(x.year+1, x.month, x.day),
+        Indicator.SEMI_ANNUAL: lambda x: datetime.date(
+            x.year + 1 if x.month > 6 else x.year,
+            x.month - 6 if x.month > 6 else x.month + 6,
+            x.day
+        ) - datetime.timedelta(days=1),
+        Indicator.TRI_ANNUAL: lambda x: datetime.date(
+            x.year + 1 if x.month > 8 else x.year,
+            x.month - 8 if x.month > 8 else x.month + 4,
+            x.day
+        ) - datetime.timedelta(days=1),
+        Indicator.QUARTERLY: lambda x: datetime.date(
+            x.year + 1 if x.month > 9 else x.year,
+            x.month - 9 if x.month > 9 else x.month + 3,
+            x.day
+        ) - datetime.timedelta(days=1),
+        Indicator.MONTHLY: lambda x: datetime.date(
+            x.year + 1 if x.month == 12 else x.year,
+            1 if x.month == 12 else x.month + 1,
+            x.day
+        ) - datetime.timedelta(days=1)
+    }
+
+    def setUp(self):
+        settings.DEBUG = True
+        self.program = None
+        self.indicator = None
+        self.data = []
+        self.targets = []
+
+    def tearDown(self):
+        for datum in self.data:
+            datum.delete()
+        for target in self.targets:
+            target.delete()
+        if self.indicator is not None:
+            self.indicator.delete()
+        if self.program is not None:
+            self.program.delete()
+
+    def load_base_indicator(self):
+        """loads a bare indicator in this program"""
+        self.indicator = i_factories.IndicatorFactory()
+        if self.program is not None:
+            self.indicator.program.add(self.program)
+            self.indicator.save()
+
+    def load_data(self, indicator=None, achieved=None, date=None, target=None):
+        """adds data to the indicator"""
+        indicator = self.indicator if indicator is None else indicator
+        achieved = 800 if achieved is None else achieved
+        date = self.program.reporting_period_start + datetime.timedelta(days=5) if date is None else date
+        datum = i_factories.CollectedDataFactory(
+            indicator=indicator,
+            achieved=achieved,
+            date_collected=date
+        )
+        if target is not None:
+            datum.periodic_target = target
+            datum.save()
+        self.data.append(datum)
+
+    def load_target(self, indicator, target, period=None, start_date=None):
+        end_date = start_date
+        period = "Period {0}".format(len(self.targets)) if period is None else period
+        if start_date is not None:
+            end_date = self.DATE_FUNCS[indicator.target_frequency](start_date)
+        self.targets.append(
+            i_factories.PeriodicTargetFactory(
+                indicator=indicator,
+                period=period,
+                target=target,
+                start_date=start_date,
+                end_date=end_date
+            )
+        )
+
+    def get_time_aware_dates(self, target_frequency):
+        start_date = self.program.reporting_period_start
+        date_func = self.DATE_FUNCS[target_frequency]
+        end_date = date_func(start_date)
+        dates = [start_date,]
+        while end_date < self.program.reporting_period_end:
+            start_date = end_date + datetime.timedelta(days=1)
+            end_date = date_func(start_date)
+            dates.append(start_date)
+        return dates
+
+    def load_targets(self, indicator=None, targets=None):
+        indicator = self.indicator if indicator is None else indicator
+        target_frequency = indicator.target_frequency
+        if target_frequency == Indicator.MID_END:
+            targets = [500, 800] if targets is None else targets
+            self.load_target(indicator, targets[0], period=PeriodicTarget.MIDLINE)
+            self.load_target(indicator, targets[1], period=PeriodicTarget.ENDLINE)
+        elif target_frequency == Indicator.EVENT:
+            targets = [1200,] if targets is None else targets
+            for target in targets:
+                self.load_target(indicator, target)
+        elif target_frequency in self.TIME_AWARE_FREQUENCIES:
+            dates = self.get_time_aware_dates(target_frequency)
+            targets = [400]*len(dates) if targets is None else targets
+            for target, start_date in zip(targets, dates):
+                self.load_target(indicator, target, start_date=start_date)
+
+
+    def get_annotated_program(self, program=None):
+        program = self.program if program is None else program
+        return ProgramWithMetrics.objects.get(pk=program.id)
+
+    def query_assert(self, baseline, expected_count, query_type):
+        new_baseline = len(db.connection.queries)
+        self.assertEqual(
+            new_baseline-baseline, expected_count,
+            "Expected {0} query to take {1} queries, took {2}".format(
+                query_type, expected_count, new_baseline-baseline))
+        return new_baseline
+
+    def get_closed_program(self):
+        self.program = w_factories.ProgramFactory(
+            reporting_period_start=datetime.date.today() - datetime.timedelta(days=366),
+            reporting_period_end=datetime.date.today()-datetime.timedelta(days=2)
+        )
+
+class TestSingleNonReportingIndicator(ReportingIndicatorBase):
+
+    def one_incomplete_assert(self, program, scenario):
+        self.assertEqual(
+            program.nonreporting.count(), 1,
+            "For {0}, program should have 1 incomplete indicator, got {1}".format(
+                scenario, program.nonreporting.count()
+            )
+        )
+        self.assertEqual(
+            program.reporting.count(), 0,
+            "For {0}, program should have 0 complete indicators, got {1}".format(
+                scenario, program.reporting.count()
+            )
+        )
+
+    def test_lop_indicator_in_open_program(self):
+        # get open (reporting period not over) program:
+        # set dates from today so test doesn't become obsolete at some arbitrary future date:
+        start_date = datetime.date.today() - datetime.timedelta(days=10)
+        end_date = datetime.date.today() + datetime.timedelta(days=100)
+        self.program = w_factories.ProgramFactory(
+            reporting_period_start=start_date,
+            reporting_period_end=end_date
+        )
+        self.load_base_indicator()
+        self.indicator.target_frequency = Indicator.LOP
+        # lop_target and data should be set to ensure it's only program openness restricting from "complete"
+        self.indicator.lop_target = 1000
+        self.indicator.save()
+        self.load_data()
+        baseline = len(db.connection.queries)
+        program = self.get_annotated_program(self.program)
+        baseline = self.query_assert(baseline, 1, "fetch program")
+        incomplete = program.nonreporting
+        self.assertEqual(
+            incomplete.count(), 1,
+            "LOP program with open program reporting period should be in incomplete"
+        )
+        baseline = self.query_assert(baseline, 1, "count incompletes")
+        complete = program.reporting
+        self.assertEqual(
+            complete.count(), 0,
+            "No indicators should be reporting as complete"
+        )
+        self.query_assert(baseline, 1, "count completes")
+
+    def test_lop_indicator_no_lop_target(self):
+        #program is complete:
+        self.get_closed_program()
+        # add indicator with data:
+        self.load_base_indicator()
+        self.indicator.target_frequency = Indicator.LOP
+        self.indicator.save()
+        self.load_data()
+        program = self.get_annotated_program(self.program)
+        self.one_incomplete_assert(program, "lop indicator, no lop_target")
+
+    def test_lop_indicator_no_data(self):
+        self.get_closed_program()
+        self.load_base_indicator()
+        self.indicator.target_frequency = Indicator.LOP
+        self.indicator.lop_target = 1400
+        self.indicator.save()
+        program = self.get_annotated_program(self.program)
+        self.one_incomplete_assert(program, "lop indicator, no data")
+
+    def test_midend_indicator_no_targets(self):
+        self.get_closed_program()
+        self.load_base_indicator()
+        self.indicator.target_frequency = Indicator.MID_END
+        self.indicator.save()
+        # ensure indicator has data for midline indicator:
+        self.load_data()
+        program = self.get_annotated_program(self.program)
+        self.one_incomplete_assert(program, "midend indicator no periodic targets")
+
+    def test_midend_indicator_no_data(self):
+        self.get_closed_program()
+        self.load_base_indicator()
+        self.indicator.target_frequency = Indicator.MID_END
+        self.indicator.save()
+        # ensure indicator has targets for midline indicator:
+        self.load_targets()
+        program = self.get_annotated_program(self.program)
+        self.one_incomplete_assert(program, "midend indicator no data")
+
+    def test_event_indicator_no_target(self):
+        self.get_closed_program()
+        self.load_base_indicator()
+        self.indicator.target_frequency = Indicator.EVENT
+        self.indicator.save()
+        self.load_data()
+        program = self.get_annotated_program(self.program)
+        self.one_incomplete_assert(program, "event, no targets")
+
+    def test_event_indicator_no_data(self):
+        self.get_closed_program()
+        self.load_base_indicator()
+        self.indicator.target_frequency = Indicator.EVENT
+        self.indicator.save()
+        self.load_targets()
+        program = self.get_annotated_program(self.program)
+        self.one_incomplete_assert(program, "event, no data")
+
+    def test_time_aware_indicators_no_targets(self):
+        self.get_closed_program()
+        for frequency in self.TIME_AWARE_FREQUENCIES:
+            self.load_base_indicator()
+            self.indicator.target_frequency = frequency
+            self.indicator.save()
+            self.load_data()
+            program = self.get_annotated_program(self.program)
+            self.one_incomplete_assert(
+                program, "{0} freq, no targets".format(self.indicator.get_target_frequency_display()))
+            for datum in self.data:
+                datum.delete()
+            self.data = []
+            self.indicator.delete()
+            self.indicator = None
+
+    def test_time_aware_indicators_no_data(self):
+        self.get_closed_program()
+        for frequency in self.TIME_AWARE_FREQUENCIES:
+            self.load_base_indicator()
+            self.indicator.target_frequency = frequency
+            self.indicator.save()
+            self.load_targets()
+            program = self.get_annotated_program(self.program)
+            self.one_incomplete_assert(
+                program, "{0} freq, no data".format(self.indicator.get_target_frequency_display()))
+            for target in self.targets:
+                target.delete()
+            self.targets = []
+            self.indicator.delete()
+            self.indicator = None
+
+    def test_time_aware_indicators_no_completed_periods(self):
+        # if program started yesterday then no targets will be finished by today:
+        self.program = w_factories.ProgramFactory(
+            reporting_period_start=datetime.date.today()-datetime.timedelta(days=1),
+            reporting_period_end=datetime.date.today()+datetime.timedelta(days=365)
+        )
+        for frequency in self.TIME_AWARE_FREQUENCIES:
+            self.load_base_indicator()
+            self.indicator.target_frequency = frequency
+            self.indicator.save()
+            self.load_targets()
+            self.load_data(date=datetime.date.today()-datetime.timedelta(days=1), target=self.targets[0])
+            program = self.get_annotated_program(self.program)
+            self.one_incomplete_assert(
+                program, "{0} freq, no complete periods".format(self.indicator.get_target_frequency_display()))
+            for target in self.targets:
+                target.delete()
+            self.targets = []
+            self.indicator.delete()
+            self.indicator = None
+
+
+class TestSingleReportingIndicator(ReportingIndicatorBase):
+    def one_complete_assert(self, program, scenario):
+        self.assertEqual(
+            program.reporting.count(), 1,
+            "In {0} query expected 1 complete, got {1}".format(
+                scenario, program.reporting.count()
+            )
+        )
+        self.assertEqual(
+            program.nonreporting.count(), 0,
+            "In {0} query expected 0 incomplete, got {1}".format(
+                scenario, program.nonreporting.count()
+            )
+        )
+
+    def test_lop_indicator_closed_program_target_set_with_data(self):
+        #program is complete:
+        self.get_closed_program()
+        # add indicator with data:
+        self.load_base_indicator()
+        self.indicator.target_frequency = Indicator.LOP
+        self.indicator.lop_target = 1400
+        self.indicator.save()
+        self.load_data()
+        program = self.get_annotated_program(self.program)
+        self.one_complete_assert(program, "one lop indicator")
+
+    def test_midend_indicator_midline_target_and_data(self):
+        self.get_closed_program()
+        self.load_base_indicator()
+        self.indicator.target_frequency = Indicator.MID_END
+        self.indicator.save()
+        # ensure indicator has targets for midline indicator:
+        self.load_target(self.indicator, 800, period=PeriodicTarget.MIDLINE)
+        self.load_data(indicator=self.indicator, achieved=500, date=None, target=self.targets[0])
+        program = self.get_annotated_program(self.program)
+        self.one_complete_assert(program, "midend indicator")
+
+    def test_midend_indicator_both_targets_and_data(self):
+        self.get_closed_program()
+        self.load_base_indicator()
+        self.indicator.target_frequency = Indicator.MID_END
+        self.indicator.save()
+        # ensure indicator has targets for midline indicator:
+        self.load_target(self.indicator, 800, period=PeriodicTarget.MIDLINE)
+        self.load_target(self.indicator, 400, period=PeriodicTarget.ENDLINE)
+        self.load_data(indicator=self.indicator, achieved=500, date=None, target=self.targets[0])
+        self.load_data(indicator=self.indicator, achieved=700, date=None, target=self.targets[1])
+        program = self.get_annotated_program(self.program)
+        self.one_complete_assert(program, "midend indicator")
+
+    def test_event_indicator_with_target_and_data(self):
+        self.get_closed_program()
+        self.load_base_indicator()
+        self.indicator.target_frequency = Indicator.EVENT
+        self.indicator.save()
+        # ensure indicator has targets for midline indicator:
+        self.load_target(self.indicator, 800)
+        self.load_data(indicator=self.indicator, achieved=500, date=None, target=self.targets[0])
+        program = self.get_annotated_program(self.program)
+        self.one_complete_assert(program, "event indicator")
+
+    def test_time_aware_indicators_with_completed_targets_and_data(self):
+        self.get_closed_program()
+        for frequency in self.TIME_AWARE_FREQUENCIES:
+            self.load_base_indicator()
+            self.indicator.target_frequency = frequency
+            self.indicator.save()
+            self.load_targets()
+            self.load_data()
+            program = self.get_annotated_program(self.program)
+            self.one_complete_assert(
+                program, "{0} freq".format(self.indicator.get_target_frequency_display()))
+            for target in self.targets:
+                target.delete()
+            for datum in self.data:
+                datum.delete()
+            self.data = []
+            self.targets = []
+            self.indicator.delete()
+            self.indicator = None
+
+
+class TestMixedReportingAndNonIndicators(ReportingIndicatorBase):
+    def setUp(self):
+        super(TestMixedReportingAndNonIndicators, self).setUp()
+        self.indicators = []
+
+    def tearDown(self):
+        super(TestMixedReportingAndNonIndicators, self).tearDown()
+        for indicator in self.indicators:
+            indicator.delete()
+
+    def test_lop_and_midend_just_mid_reporting(self):
+        self.get_closed_program()
+        indicator_lop = i_factories.IndicatorFactory(
+            target_frequency=Indicator.LOP,
+            lop_target=1000
+        )
+        indicator_lop.program.add(self.program)
+        indicator_lop.save()
+        self.indicators.append(indicator_lop)
+        lop_data = i_factories.CollectedDataFactory(
+            indicator=indicator_lop,
+            achieved=400,
+            date_collected=self.program.reporting_period_end - datetime.timedelta(days=10)
+        )
+        self.data.append(lop_data)
+        indicator_midend = i_factories.IndicatorFactory(
+            target_frequency=Indicator.MID_END
+        )
+        indicator_midend.program.add(self.program)
+        indicator_midend.save()
+        self.indicators.append(indicator_midend)
+        mid_target = i_factories.PeriodicTargetFactory(
+            indicator=indicator_midend,
+            period=PeriodicTarget.MIDLINE,
+            target=1000
+        )
+        self.targets.append(mid_target)
+        mid_data = i_factories.CollectedDataFactory(
+            indicator=indicator_midend,
+            periodic_target=mid_target,
+            achieved=400,
+            date_collected=self.program.reporting_period_start + datetime.timedelta(days=20)
+        )
+        self.data.append(mid_data)
+        baseline = len(db.connection.queries)
+        program = self.get_annotated_program(self.program)
+        baseline = self.query_assert(baseline, 1, "fetch program, two indicators")
+        reporting = program.reporting.count()
+        self.assertEqual(
+            reporting, 2,
+            "expected both midend and lop indicators to be reporting, got {0}".format(reporting)
+        )
+        baseline = self.query_assert(baseline, 1, "reporting count, two indicators")
+        nonreporting = program.nonreporting.count()
+        self.assertEqual(
+            nonreporting, 0,
+            "expected no nonreporting indicators, got {0}".format(nonreporting)
+        )
+
+    def test_multiple_time_aware_indicators(self):
+        self.get_closed_program()
+        for frequency in self.TIME_AWARE_FREQUENCIES:
+            indicator = i_factories.IndicatorFactory(
+                target_frequency=frequency
+            )
+            indicator.program.add(self.program)
+            indicator.save()
+            self.load_targets(indicator=indicator)
+            self.load_data(indicator=indicator)
+        program = self.get_annotated_program(self.program)
+        reporting = program.reporting.count()
+        self.assertEqual(
+            reporting, len(self.TIME_AWARE_FREQUENCIES),
+            "expected {0} reporting indicators, got {1}, qs: {2}".format(
+                len(self.TIME_AWARE_FREQUENCIES), reporting, program.reporting.all()
+            )
+        )
+        self.assertEqual(
+            program.nonreporting.count(), 0,
+            "expected 0 nonreporting timeaware indicators, got {0}".format(program.nonreporting.count())
+        )

--- a/indicators/tests/test_temp.py
+++ b/indicators/tests/test_temp.py
@@ -1,0 +1,395 @@
+import sys
+from datetime import datetime
+from indicators.queries import IPTTIndicator
+from indicators.models import Indicator
+from factories.indicators_models import (
+    IndicatorFactory,
+    LevelFactory,
+    PeriodicTargetFactory,
+    CollectedDataFactory
+    )
+from factories.workflow_models import ProgramFactory
+from django import test
+from django.core.exceptions import ValidationError
+
+from django.conf import settings
+from django.db import connection
+
+""" cases
+    - cumulative number +
+        - lop target: last target
+        - lop result: sum of all data
+        - period result: sum of data to date
+    - cumulative number - (this one might change) (flip bad and good)
+        - same as above
+    - cumulative percent +
+        - lop target: last target
+        - lop result: last result
+        - period result: last result
+    - cumulative percent -
+        - same as above (flip bad and good)
+    - noncumulative number +
+        - lop target: sum of targets
+        - lop result: sum of all data
+        - period result: sum of data in period
+    - noncumulative number -
+        - same as above (flip bad and good)
+    - noncumulative percent + : no results
+    - noncumulative precent - : no results
+"""
+
+dates = {
+    'program_start': (1, 1),
+    'program_end': (12, 31),
+    'targets': [
+        ((1, 1), (4, 30)),
+        ((5, 1), (8, 31)),
+        ((9, 1), (12, 31))
+    ],
+    'collects': [
+        ((2, 1),),
+        ((6, 1), (8, 10)),
+        ((10, 20),)
+    ]
+}
+
+def get_date(date_tuple):
+    return datetime(2016, date_tuple[0], date_tuple[1])
+
+scenarios = [
+    {
+        'desc': 'cumulative number positive',
+        'cumulative': True,
+        'number': True,
+        'positive': True,
+        'targets': [50, 100, 150],
+        'data': [(40,), (30, 30), (45,)],
+        'blank': False,
+        'lop_target': 150,
+        'lop_sum': 145,
+        'lop_met': '97%',
+        'results': [40, 100, 145],
+        'mets': ['80%', '100%', '97%'],
+        'over_under': [-1, 0, 0],
+        'semi_annual_results': [70, 145],
+    },
+    {
+        'desc': 'cumulative number negative',
+        'cumulative': True,
+        'number': True,
+        'positive': False,
+        'targets': [300, 200, 100],
+        'data': [(100,), (50, 80), (40,)],
+        'blank': False,
+        'lop_target': 100,
+        'lop_sum': 270,
+        'lop_met': '270%',
+        'results': [100, 230, 270],
+        'mets': ['33%', '115%', '270%'],
+        'over_under': [1, 0, -1],
+        'semi_annual_results': [150, 270]
+    },
+    {
+        'desc': 'cumulative percent positive',
+        'cumulative': True,
+        'number': False,
+        'positive': True,
+        'targets': [50, 60, 70],
+        'data': [(40,), (50, 55,), (75,)],
+        'blank': False,
+        'lop_target': 70,
+        'lop_sum': 75,
+        'lop_met': '107%',
+        'results': [40, 55, 75],
+        'mets': ['80%', '92%', '107%'],
+        'over_under': [-1, 0, 0],
+        'semi_annual_results': ['50%', '75%']
+    },
+    {
+        'desc': 'cumulative percent negative',
+        'cumulative': True,
+        'number': False,
+        'positive': False,
+        'targets': [80, 40, 20],
+        'data': [(75,), (35, 55), (25,)],
+        'blank': False,
+        'lop_target': 20,
+        'lop_sum': 25,
+        'lop_met': '125%',
+        'results': [75, 55, 25],
+        'mets': ['94%', '138%', '125%'],
+        'over_under': [0, -1, -1],
+        'semi_annual_results': ['35%', '25%']
+    },
+    {
+        'desc': 'noncumulative number positive',
+        'cumulative': False,
+        'number': True,
+        'positive': True,
+        'targets': [100, 100, 100],
+        'data': [(80,), (40, 70), (90,)],
+        'blank': False,
+        'lop_target': 300,
+        'lop_sum': 280,
+        'lop_met': '93%',
+        'results': [80, 110, 90],
+        'mets': ['80%', '110%', '90%'],
+        'over_under': [-1, 0, 0],
+        'semi_annual_results': [120, 160]
+    },
+    {
+        'desc': 'noncumulative number negative',
+        'cumulative': False,
+        'number': True,
+        'positive': False,
+        'targets': [500, 500, 500],
+        'data': [(400,), (300, 200), (600,)],
+        'blank': False,
+        'lop_target': 1500,
+        'lop_sum': 1500,
+        'lop_met': '100%',
+        'results': [400, 500, 600],
+        'mets': ['80%', '100%', '120%'],
+        'over_under': [1, 0, -1],
+        'semi_annual_results': [700, 800]
+    },
+    {
+        'desc': 'noncumulative percent positive',
+        'cumulative': False,
+        'number': False,
+        'positive': True,
+        'targets': [30, 30, 30],
+        'data': [(30,), (20,), (50,)],
+        'blank': True
+    },
+    {
+        'desc': 'noncumulative percent negative',
+        'cumulative': False,
+        'number': False,
+        'positive': False,
+        'targets': [30, 30, 30],
+        'data': [(30,), (20,), (50,)],
+        'blank': True
+    }
+]
+
+class TestIndicatorInstance(test.TestCase):
+
+    def setUp(self):
+        self.indicator = IndicatorFactory(name="testname")
+        self.level = LevelFactory()
+        self.indicator.level.add(self.level)
+
+    def tearDown(self):
+        self.level.delete()
+        self.indicator.delete()
+
+    def test_instances(self):
+        indicators = IPTTIndicator.notargets.all()
+        self.assertEqual(len(indicators), 1)
+        self.assertEqual(indicators[0].name, self.indicator.name)
+
+    def test_level(self):
+        indicator = IPTTIndicator.notargets.first()
+        self.assertEqual(indicator.level_name, self.level.name)
+
+class TestIndicatorScenarios(test.TestCase):
+    def setUp(self):
+        self.program = ProgramFactory(reporting_period_start=get_date(dates['program_start']),
+                                      reporting_period_end=get_date(dates['program_end']))
+        self.indicator = None
+        self.targets = []
+        self.data = []
+
+    def tearDown(self):
+        for data in self.data:
+            data.delete()
+        for target in self.targets:
+            target.delete()
+        if self.indicator is not None:
+            self.indicator.delete()
+        self.program.delete()
+
+    def indicator_for_scenario(self, scenario):
+        indicator = IndicatorFactory(
+            target_frequency=Indicator.TRI_ANNUAL,
+            is_cumulative=scenario['cumulative'],
+            direction_of_change=(
+                Indicator.DIRECTION_OF_CHANGE_POSITIVE
+                if scenario['positive'] else Indicator.DIRECTION_OF_CHANGE_NEGATIVE
+            ),
+            unit_of_measure_type=(
+                Indicator.NUMBER if scenario['number'] else Indicator.PERCENTAGE
+            )
+        )
+        indicator.program.add(self.program)
+        indicator.save()
+        for target_number, period in zip(scenario['targets'], dates['targets']):
+            self.targets.append(PeriodicTargetFactory(
+                indicator=indicator,
+                target=target_number,
+                start_date=get_date(period[0]),
+                end_date=get_date(period[1])
+            ))
+        for c, data_set in enumerate(scenario['data']):
+            date_set = dates['collects'][c]
+            for data, date in zip(data_set, date_set):
+                self.data.append(CollectedDataFactory(
+                    periodic_target=self.targets[c],
+                    achieved=data,
+                    indicator=indicator,
+                    program=self.program,
+                    date_collected=get_date(date)
+                ))
+        return indicator
+
+    def get_scenarios(self):
+        for scenario in scenarios:
+            try:
+                self.indicator = self.indicator_for_scenario(scenario)
+            except ValidationError:
+                exc_type, exc_value = sys.exc_info()[:2]
+                self.fail("{0} in {1} scenario: {2}".format(exc_type.__name__, scenario['desc'], ",".join(exc_value)))
+            self.assertEqual(self.indicator.program.first(), self.program)
+            yield scenario
+
+    def test_scenario_totals_targetperiods(self):
+        settings.DEBUG = True
+        for scenario in self.get_scenarios():
+            created = len(connection.queries)
+            iptt_indicator = IPTTIndicator.withtargets.get(pk=self.indicator.pk)
+            expected_queries = 2
+            self.assertEqual(
+                len(connection.queries)-created, expected_queries,
+                "Expecting {0} query to fetch indicator, but it took {1}".format(
+                    expected_queries, len(connection.queries)-created))
+            # make sure iptt indicator proxy loaded correctly:
+            self.assertEqual(iptt_indicator.pk, self.indicator.pk)
+            if scenario['blank']:
+                # no tests on a blank (unsupported for annotations) indicator:
+                return
+            self.assertEqual(
+                iptt_indicator.lop_target_sum,
+                scenario['lop_target'],
+                "In scenario {desc}: calculated lop_target_sum should be {1}, got {0}".format(
+                    iptt_indicator.lop_target_sum, scenario['lop_target'],
+                    desc=scenario['desc']))
+            self.assertEqual(
+                iptt_indicator.lop_actual_sum,
+                scenario['lop_sum'],
+                "In scenario {desc}: calculated lop sum should be {0}, got {1}".format(
+                    scenario['lop_sum'], iptt_indicator.lop_actual_sum,
+                    desc=scenario['desc']))
+            self.assertEqual(
+                iptt_indicator.lop_met_target,
+                scenario['lop_met'],
+                "In scenarios {desc}: lop met_target should be {0}, got {1}".format(
+                    scenario['lop_met'], iptt_indicator.lop_met_target,
+                    desc=scenario['desc']))
+
+    def test_scenario_totals_timeperiods(self):
+        settings.DEBUG = True
+        for scenario in self.get_scenarios():
+            created = len(connection.queries)
+            iptt_indicator = IPTTIndicator.notargets.get(pk=self.indicator.pk)
+            expected_queries = 2
+            self.assertEqual(
+                len(connection.queries)-created, expected_queries,
+                "Expecting {0} query to fetch indicator, but it took {1}".format(
+                    expected_queries, len(connection.queries)-created))
+            # make sure iptt indicator proxy loaded correctly:
+            self.assertEqual(iptt_indicator.pk, self.indicator.pk)
+            if scenario['blank']:
+                # no tests on a blank (unsupported for annotations) indicator:
+                return
+            self.assertEqual(
+                iptt_indicator.lop_target_sum,
+                scenario['lop_target'],
+                "In scenario {desc}: calculated lop_target_sum should be {1}, got {0}".format(
+                    iptt_indicator.lop_target_sum, scenario['lop_target'],
+                    desc=scenario['desc']))
+            self.assertEqual(
+                iptt_indicator.lop_actual_sum,
+                scenario['lop_sum'],
+                "In scenario {desc}: calculated lop sum should be {0}, got {1}".format(
+                    scenario['lop_sum'], iptt_indicator.lop_actual_sum,
+                    desc=scenario['desc']))
+            self.assertEqual(
+                iptt_indicator.lop_met_target,
+                scenario['lop_met'],
+                "In scenarios {desc}: lop met_target should be {0}, got {1}".format(
+                    scenario['lop_met'], iptt_indicator.lop_met_target,
+                    desc=scenario['desc']))
+
+    def test_periodic_target_scenarios(self):
+        settings.DEBUG = True
+        for scenario in self.get_scenarios():
+            created = len(connection.queries)
+            indicator = IPTTIndicator.withtargets.get(pk=self.indicator.pk)
+            expected_queries = 2 #one for each target
+            self.assertEqual(
+                len(connection.queries)-created, expected_queries,
+                "Expecting {0} queries to fetch indicator, but it took {1}".format(
+                    expected_queries, len(connection.queries)-created))
+            if scenario['blank']:
+                return
+            self.assertEqual(
+                len(indicator.data_targets),
+                len(scenario['targets']),
+                "In {desc}: expecting {0} indicator targets, got {1}".format(
+                    len(scenario['targets']), len(indicator.data_targets),
+                    desc=scenario['desc']))
+            for c, target_actual in enumerate(indicator.data_targets):
+                self.assertEqual(
+                    target_actual.target,
+                    scenario['targets'][c],
+                    "In {desc}: expected {0} for target {1}, but got {2}".format(
+                        scenario['targets'][c], c, target_actual.target,
+                        desc=scenario['desc']))
+                self.assertEqual(
+                    target_actual.data_sum,
+                    scenario['results'][c],
+                    "In {desc}: expected a sum of {0} for target {1}, but got {2}".format(
+                        scenario['results'][c], c, target_actual.data_sum,
+                        desc=scenario['desc']))
+                self.assertEqual(
+                    target_actual.met,
+                    scenario['mets'][c],
+                    "In {desc}: expected a met of {0} for target {1}, but got {2}".format(
+                        scenario['mets'][c], c, target_actual.met,
+                        desc=scenario['desc']))
+                self.assertEqual(
+                    target_actual.within_target_range,
+                    scenario['over_under'][c],
+                    "In {desc}: expected {0} within_target_range to be {1}, got {2}".format(
+                        c, scenario['over_under'][c], target_actual.within_target_range,
+                        desc=scenario['desc']))
+            self.assertEqual(
+                len(connection.queries)-created, expected_queries,
+                "(after all tests): expecting {0} queries to fetch indicator, but it took {1}".format(
+                    expected_queries, len(connection.queries)-created))
+
+    def test_timeperiod_scenarios(self):
+        settings.DEBUG = True
+        periods = [
+            {
+                'start_date': datetime(2016, 1, 1),
+                'end_date': datetime(2016, 6, 30),
+            },
+            {
+                'start_date': datetime(2016, 7, 1),
+                'end_date': datetime(2016, 12, 31)
+            }]
+        for scenario in self.get_scenarios():
+            created = len(connection.queries)
+            indicator = IPTTIndicator.notargets.periods(periods)
+            expected_queries = 2
+            self.assertEqual(
+                len(connection.queries)-created, expected_queries,
+                "Expecting {0} queries to fetch indicator, but it took {1}".format(
+                    expected_queries, len(connection.queries)-created))
+            self.assertEqual(
+                len(indicator.timeperiods),
+                len(scenario['semi_annual_results']),
+                "Expected {0} timeperiods, got {1}".format(
+                    len(scenario['semi_annual_results']), len(indicator.timeperiods)))

--- a/indicators/urls.py
+++ b/indicators/urls.py
@@ -32,17 +32,19 @@ from .views.views_reports import (
     IPTTReportQuickstartView,
     IPTT_ReportView,
     IPTT_ReportIndicatorsWithVariedStartDate,
-    IPTT_ExcelExport
+    IPTT_ExcelExport,
+    IPTT_CSVExport
 )
+
 
 urlpatterns = [
     url(r'^home/(?P<program>\d+)/(?P<indicator>\d+)/(?P<type>\d+)/$', IndicatorList.as_view(), name='indicator_list'),
 
-    url(r'^indicator_create/(?P<id>\d+)/$', indicator_create,  name='indicator_create'),
+    url(r'^indicator_create/(?P<id>\d+)/$', indicator_create, name='indicator_create'),
 
     url(r'^indicator_add/(?P<id>\d+)/$', IndicatorCreate.as_view(), name='indicator_add'),
 
-    url(r'^indicator_update/(?P<pk>\d+)/$', IndicatorUpdate.as_view(),  name='indicator_update'),
+    url(r'^indicator_update/(?P<pk>\d+)/$', IndicatorUpdate.as_view(), name='indicator_update'),
 
     url(r'^indicator_delete/(?P<pk>\d+)/$', IndicatorDelete.as_view(), name='indicator_delete'),
 
@@ -56,7 +58,7 @@ urlpatterns = [
     url(r'^collecteddata_add/(?P<program>\d+)/(?P<indicator>\d+)/$',
         CollectedDataCreate.as_view(), name='collecteddata_add'),
 
-    url(r'^collecteddata_import/$', collecteddata_import,  name='collecteddata_import'),
+    url(r'^collecteddata_import/$', collecteddata_import, name='collecteddata_import'),
 
     url(r'^collecteddata_update/(?P<pk>\d+)/$', CollectedDataUpdate.as_view(), name='collecteddata_update'),
 
@@ -75,7 +77,7 @@ urlpatterns = [
     url(r'^report_table/(?P<program>\d+)/(?P<indicator>\d+)/(?P<type>\d+)/$',
         IndicatorReport.as_view(), name='indicator_table'),
 
-    url(r'^program_report/(?P<program>\d+)/$', programIndicatorReport,  name='programIndicatorReport'),
+    url(r'^program_report/(?P<program>\d+)/$', programIndicatorReport, name='programIndicatorReport'),
 
 
     url(r'^export/(?P<id>\d+)/(?P<program>\d+)/(?P<indicator_type>\d+)/$',
@@ -115,4 +117,7 @@ urlpatterns = [
         name='iptt_redirect'),
 
     url(r'^iptt_excel/(?P<program_id>\d+)/(?P<reporttype>\w+)/$', IPTT_ExcelExport.as_view(), name='iptt_excel'),
+
+    url(r'^iptt_csv/(?P<program_id>\d+)/$', IPTT_CSVExport.as_view(), name='iptt_csv'),
+
 ]

--- a/indicators/urls.py
+++ b/indicators/urls.py
@@ -118,6 +118,6 @@ urlpatterns = [
 
     url(r'^iptt_excel/(?P<program_id>\d+)/(?P<reporttype>\w+)/$', IPTT_ExcelExport.as_view(), name='iptt_excel'),
 
-    url(r'^iptt_csv/(?P<program_id>\d+)/$', IPTT_CSVExport.as_view(), name='iptt_csv'),
+    url(r'^iptt_csv/(?P<program_id>\d+)/(?P<reporttype>\w+)/$', IPTT_CSVExport.as_view(), name='iptt_csv'),
 
 ]

--- a/indicators/views/views_reports.py
+++ b/indicators/views/views_reports.py
@@ -1,9 +1,10 @@
 import bisect
+import csv
 from collections import OrderedDict
-from dateutil import rrule, parser
-from django.utils import formats, timezone
-from dateutil.relativedelta import relativedelta
 from datetime import datetime
+from dateutil import rrule, parser
+from dateutil.relativedelta import relativedelta
+from django.utils import formats, timezone
 from django.core.urlresolvers import reverse_lazy
 from django.db.models import Sum, Avg, Subquery, OuterRef, Case, When, Q, F, Max
 from django.views.generic import TemplateView, FormView
@@ -1171,3 +1172,16 @@ class IPTT_ReportView(IPTT_Mixin, TemplateView):
         redirect_url = "{}?{}".format(reverse_lazy('iptt_report', kwargs=url_kwargs),
                                       filterdata.urlencode())
         return HttpResponseRedirect(redirect_url)
+
+class IPTT_CSVExport(IPTT_Mixin, TemplateView):
+    header_row = ["Program:"]
+    subheader_row = ["id", "name"]
+
+    def get(self, request, *args, **kwargs):
+        context = self.get_context_data(**kwargs)
+        self.header_row.append(self.program.name)
+        response = HttpResponse(content_type="text/csv")
+        writer = csv.writer(response)
+        writer.writerow(self.header_row)
+        writer.writerow(self.subheader_row)
+        return response


### PR DESCRIPTION
tests include query counts (at most 2 for fully annotated indicator with target and data associated, otherwise 1 for program with annotations, and 1 for any subset of program indicators)
verified rows aren't doubled
verified business logic for counting indicator targets and data
added methods to ProgramWithMetrics (a proxy model acting on the Program table): 
- ontarget: returns a queryset of ontarget indicators (so ontarget.count() gets the number for finding percents)
- overtarget and undertarget (same as above)
- nonreporting: returns a queryset of indicators not being counted in the above three