### PR TITLE
Fix broken test based on indicator ordering in iptt view

### DIFF
--- a/indicators/tests/test_iptt_targetperiods_report.py
+++ b/indicators/tests/test_iptt_targetperiods_report.py
@@ -12,14 +12,18 @@ from indicators.models import Indicator, CollectedData, PeriodicTarget
 
 class TestPeriodicTargetsBase(iptt_utility.TestIPTTTargetPeriodsReportResponseBase):
     def setUp(self):
+        self.program = None
         super(TestPeriodicTargetsBase, self).setUp()
         self.indicators = []
 
     def tearDown(self):
-        super(TestPeriodicTargetsBase, self).tearDown()
+        CollectedData.objects.all().delete()
         PeriodicTarget.objects.all().delete()
         Indicator.objects.all().delete()
-        CollectedData.objects.all().delete()
+        super(TestPeriodicTargetsBase, self).tearDown()
+        if self.program is not None:
+            self.program.delete()
+        self.indicators = []
 
     def set_reporting_period(self, start, end):
         self.program.reporting_period_start = datetime.strptime(start, '%Y-%m-%d')

--- a/indicators/views/views_reports.py
+++ b/indicators/views/views_reports.py
@@ -348,7 +348,7 @@ class IPTT_Mixin(object):
         periodic_targets = PeriodicTarget.objects.filter(
             indicator__program__in=[program.id],
             indicator__target_frequency=period
-        ).values("period", "target", "start_date", "end_date")
+        ).values("period", "target", "start_date", "end_date").order_by("start_date")
 
         try:
             start_date = parser.parse(self.filter_form_initial_data['start_date']).date()
@@ -372,7 +372,6 @@ class IPTT_Mixin(object):
             report_end_date = targetperiods[targetperiods.keys()[-1]][1]
         except (TypeError, IndexError):
             report_end_date = self.program.reporting_period_end
-
         # this check is necessary becasue mid/end line do not have start/end dates
         if report_end_date is None:
             report_end_date = self.program.reporting_period_end


### PR DESCRIPTION
Adding an ordering to views_reports target grabbing to ensure report end date will be found correctly.