### PR TITLE
settings.DEBUG being left on True causes Travis failures

### DIFF
--- a/indicators/tests/test_program_indicator_queries.py
+++ b/indicators/tests/test_program_indicator_queries.py
@@ -303,6 +303,7 @@ class TestProgramReportingingCounts (test.TestCase):
         for indicator in self.indicators:
             indicator.delete()
         self.program.delete()
+        settings.DEBUG = False
 
     def get_base_indicator(self):
         indicator = i_factories.IndicatorFactory()

--- a/indicators/tests/test_program_indicator_reporting_sort.py
+++ b/indicators/tests/test_program_indicator_reporting_sort.py
@@ -157,6 +157,7 @@ class ReportingIndicatorBase(test.TestCase):
             self.indicator.delete()
         if self.program is not None:
             self.program.delete()
+        settings.DEBUG = False
 
     def load_base_indicator(self):
         """loads a bare indicator in this program"""

--- a/indicators/tests/test_time_aware_iptt_queries.py
+++ b/indicators/tests/test_time_aware_iptt_queries.py
@@ -286,6 +286,7 @@ class TestIndicatorScenarios(test.TestCase):
                 "In scenarios {desc}: lop met_target should be {0}, got {1}".format(
                     scenario['lop_met'], iptt_indicator.lop_met_target,
                     desc=scenario['desc']))
+        settings.DEBUG = False
 
     def test_scenario_totals_timeperiods(self):
         settings.DEBUG = True
@@ -320,6 +321,7 @@ class TestIndicatorScenarios(test.TestCase):
                 "In scenarios {desc}: lop met_target should be {0}, got {1}".format(
                     scenario['lop_met'], iptt_indicator.lop_met_target,
                     desc=scenario['desc']))
+        settings.DEBUG = False
 
     def test_periodic_target_scenarios(self):
         settings.DEBUG = True
@@ -368,6 +370,7 @@ class TestIndicatorScenarios(test.TestCase):
                 len(connection.queries)-created, expected_queries,
                 "(after all tests): expecting {0} queries to fetch indicator, but it took {1}".format(
                     expected_queries, len(connection.queries)-created))
+            settings.DEBUG = False
 
     def test_timeperiod_scenarios(self):
         settings.DEBUG = True
@@ -405,3 +408,4 @@ class TestIndicatorScenarios(test.TestCase):
                         "{desc} expected {0} for sum of semi annual period {1}, got {2}".format(
                             scenario['semi_annual_results'][c], c, period_sum,
                             desc=scenario['desc']))
+        settings.DEBUG = False


### PR DESCRIPTION
Adding settings.DEBUG back to false to avoid overloading poor little Travis