### PR TITLE
Add ability to login using a django account

### DIFF
--- a/test/js/Makefile
+++ b/test/js/Makefile
@@ -68,7 +68,7 @@ run-chrome:
 run-gecko:
 	java -jar -Dwebdriver.gecko.driver=geckodriver $(SESERVER) | tee server.log 2>&1 &
 	npm run wdio wdio.gecko.conf | tee gecko.log 2>&1
-	ifeq ($(XDG_SESSION_TYPE),x11)
+	ifeq $($(XDG_SESSION_TYPE),x11)
 		-killall -w $(jobs -p)
 	else
 		-killall java

--- a/test/js/README-FIRST.md
+++ b/test/js/README-FIRST.md
@@ -1,5 +1,8 @@
 # TATS (Tola Activity Test Suite) Status
-NOTE: Wed May 23 12:41:56 PDT 2018
+NOTE:   Wed May 23 12:41:56 PDT 2018
+UPDATe: Wed Nov  7 22:51:29 PST 2018
+  This test suite was mostly passing at SHA a508aeaa at the
+  beginning of Oct 2018 after a round of cleanup
 
 This functional test project is being put on hold to focus development
 effort on unit tests. The TolaActivity UI is undergoing active, heavy 
@@ -10,9 +13,9 @@ tests focus on the IPTT reports, but I had multiple efforts going
 forward at once. If/when this project resumes, I recommend proceeding
 as follows:
 
-1. Repair tests broken by all the UI changes since 23 May 2018
+1. Repair tests broken by all the UI changes since 7 Nov 2018
 1. Implement the rest of the IPTT report tests
 1. Refactor the pre-ES6 bits into ES6
 
-Pending the explicity refactoring, I also recommend that new page objects 
+Pending the explicit refactoring, I also recommend that new page objects 
 and new tests be written in ES6 syntax and using proper JavaScript classes.

--- a/test/js/README.md
+++ b/test/js/README.md
@@ -89,14 +89,17 @@ $ cd TolaActivity/test/js
 ### Create the user config file
 Copy the example user config file to _config.json_ (`cp
 config-example.json config.json`) and edit _config.json_, changing
-_username_, _password_, and _baseurl_ to suit your needs. In particular:
+_username_, _password_, _baseurl_, and _auth_ to suit your needs. 
+In particular:
 
 - _username_ and _password_ must correspond to your MercyCorps SSO login
 - _baseurl_ points to the home page of the TolaActivity instance you
   are testing
-- When running against a local instance, set _googleauth_ to _true_ if 
-  you want to use Google authentication; seet _googleauth_ to _false_ if
-  you want to authenticate using a Django username and password
+- To authenticate against MercyCorps' SSO, set _auth_ to _"mcsso"_
+- To authenticate against GoogleAuth when running a local instance,
+  set _auth_ to _"google"_
+- To authenticate against Django when running a local instance, set 
+  _auth_ to _"django"_
 - **Under no circumstances run the TATS suite against the production
   TolaActivity server. Doing so will create bad data and result in a lot
   of work to remove it, and potentially result in losing known-good,

--- a/test/js/README.md
+++ b/test/js/README.md
@@ -59,11 +59,11 @@ make realclean install run-chrome run-gecko
 ```
 
 - The `realclean` target deletes all generated files, including the
-  _node_modules_ directory
+  *node_modules* directory
 - The `install` target, in addition to installing all the necessary
   JavaScript packages, also downloads the Selenium Server and the latest
-  known-good versions of the Chrome and Firefox WebDriver clients,
-  `chromedriver` and `geckodriver`, respectively
+  (when this doc was last updated) known-good versions of the Chrome 
+   and Firefox WebDriver clients, `chromedriver` and `geckodriver`, respectively
 - The `run-chrome` and `run-gecko` targets will start the Selenium server,
   run all of the tests for the indicated browser, and then terminate the
   server after the test completes
@@ -94,6 +94,9 @@ _username_, _password_, and _baseurl_ to suit your needs. In particular:
 - _username_ and _password_ must correspond to your MercyCorps SSO login
 - _baseurl_ points to the home page of the TolaActivity instance you
   are testing
+- When running against a local instance, set _googleauth_ to _true_ if 
+  you want to use Google authentication; seet _googleauth_ to _false_ if
+  you want to authenticate using a Django username and password
 - **Under no circumstances run the TATS suite against the production
   TolaActivity server. Doing so will create bad data and result in a lot
   of work to remove it, and potentially result in losing known-good,
@@ -113,14 +116,13 @@ steps below were current at the time this document was last updated.
    [ChromeDriver](https://sites.google.com/a/chromium.org/chromedriver).
    Place it anywhere in your system $PATH. You may also keep it in
    the testing directory of your local repo because it is gitignored.
-   The current version (when this document was last updated) is 2.37.
-   **NOTE:** Chromedriver v2.38 does not work with TATS at this time.
-   Please stick to 2.37.
+   The current version (when this document was last updated) is 
+   2.42.mumbleblatz.
 1. Download and install Firefox's Selenium browser driver,
    [geckodriver](https://github.com/mozilla/geckodriver/releases).
    Place it anywhere in your system $PATH. You can also keep it in
    the testing directory of your local repo because it is gitignored.
-   The current version (as of the last doc update) is 0.20.1.
+   The current version (as of the last doc update) is 0.23.
 1. Download [Selenium Server](https://goo.gl/hvDPsK) and place it
    the testing directory. The current version (at the time of writing) is
    3.12.0.
@@ -149,7 +151,7 @@ $ npm install
 1. Start the Seleniuim server (targeting the Firefox browser):
     ```
     $ cd test/js
-    $ java -jar -Dwebdriver.gecko.driver=./geckodriver selenium-server-standalone-3.11.0.jar &> selenium-server.log &
+    $ java -jar -Dwebdriver.gecko.driver=./geckodriver selenium-server-standalone-3.14.0.jar &> selenium-server.log &
     ```
 1. Execute the test suite:
     ```
@@ -193,8 +195,8 @@ $ ./node_modules/.bin/wdio --spec invalid
 
 Better still, you can execute a suite of related tests by specifying
 `--suite _name_`, where `_name_` is one the names defined in the 
-_suites:_ section of the config file. For example, the _evidence suite
-is defined in the _wdio.\*.conf.js_ files like so:
+_suites:_ section of the config file. To create suite named
+_evidence_ in the conf file, it might look like this:
 
 ```
         evidence: [
@@ -213,10 +215,10 @@ $ ./node_modules/.bin/wdio --suite evidence
 ```
 
 ## Looking for framework documentation?
-To produce documentation for the test framework, the API is decorated
-with JSDoc decorators, so it will produce JSDoc-compatible documentation
-from the code itself. To do so, execute the command `make doc` at the
-top of the testing directory:
+The framework API is decorated with JSDoc decorators, so it will
+produce JSDoc-compatible documentation from the code itself. To produce
+documentation for the test framework, To do so, execute the command
+`make doc` at the top of the testing directory:
 
 ```
 $ make doc

--- a/test/js/config-example.json
+++ b/test/js/config-example.json
@@ -1,5 +1,6 @@
 {
 	"username": "username",
 	"password": "password",
-    "baseurl": "https://tola-activity-dev.example.com/"
+    "baseurl": "https://tola-activity-dev.example.com/",
+    "auth": "django"
 }

--- a/test/js/lib/testutil.js
+++ b/test/js/lib/testutil.js
@@ -5,8 +5,7 @@
 import LoginPage from '../pages/login.page'
 
 // Milliseconds
-const msec = 1000
-
+const delay = LoginPage.delay
 
 /**
  * Login to a remote or local Tola instance
@@ -20,10 +19,18 @@ function loginTola() {
     LoginPage.password = parms.password
     LoginPage.login.click()
   } else if (parms.baseurl.includes('localhost')) {
-    LoginPage.googleplus.click()
-    if (LoginPage.title != 'Dashboard | TolaActivity') {
-      LoginPage.gUsername = parms.username + '@mercycorps.org'
-      LoginPage.gPassword = parms.password
+    if (parms.googleauth) {
+      LoginPage.googleplus.click()
+      if (LoginPage.title != 'Dashboard | TolaActivity') {
+        LoginPage.gUsername = parms.username + '@mercycorps.org'
+        LoginPage.gPassword = parms.password
+      }
+    } else {
+      if (LoginPage.title != 'Dashboard | TolaActivity') {
+        LoginPage.dUsername = parms.username
+        LoginPage.dPassword = parms.password
+        LoginPage.dLogin.click()
+      }
     }
   }
 }

--- a/test/js/lib/testutil.js
+++ b/test/js/lib/testutil.js
@@ -14,23 +14,22 @@ const delay = LoginPage.delay
 function loginTola() {
   let parms = readConfig()
   LoginPage.open(parms.baseurl)
-  if (parms.baseurl.includes('mercycorps.org')) {
+  if (parms.auth === 'mcsso') {
     LoginPage.username = parms.username
     LoginPage.password = parms.password
     LoginPage.login.click()
-  } else if (parms.baseurl.includes('localhost')) {
-    if (parms.googleauth) {
-      LoginPage.googleplus.click()
-      if (LoginPage.title != 'Dashboard | TolaActivity') {
-        LoginPage.gUsername = parms.username + '@mercycorps.org'
-        LoginPage.gPassword = parms.password
-      }
-    } else {
-      if (LoginPage.title != 'Dashboard | TolaActivity') {
-        LoginPage.dUsername = parms.username
-        LoginPage.dPassword = parms.password
-        LoginPage.dLogin.click()
-      }
+  } else if (parms.auth === 'django') {
+    LoginPage.dUsername = parms.username
+    LoginPage.dPassword = parms.password
+    LoginPage.dLogin.click()
+  } else if (parms.auth === 'google') {
+    // Might bypass the login screen if google auth previously used
+    // by the current browser profile...
+    LoginPage.googleplus.click()
+    // ...but if not, we're also ready to login manually
+    if (LoginPage.title != 'Dashboard | TolaActivity') {
+      LoginPage.gUsername = parms.username + '@mercycorps.org'
+      LoginPage.gPassword = parms.password
     }
   }
 }

--- a/test/js/pages/login.page.js
+++ b/test/js/pages/login.page.js
@@ -12,6 +12,21 @@ class LoginPage extends Page {
   // Independent of auth source
   get title () { return browser.getTitle() }
 
+  // These are for authentication using Django's built-in auth
+  get dUsername () { return browser.$('#id_username') }
+  get dPassword () { return browser.$('#id_password') }
+  get dLogin () {
+    let inputs = browser.$$('input')
+    for (let input of inputs) {
+      if (input.getValue() === 'login') {
+          return input
+      }
+    }
+  }
+
+  set dUsername (val) { return browser.$('#id_username').setValue(val) }
+  set dPassword (val) { return browser.$('#id_password').setValue(val) }
+
   // These are for authentication using MC's SSO
   get username () { return browser.$('#login') }
   get password () { return browser.$('#password') }
@@ -27,6 +42,7 @@ class LoginPage extends Page {
   get googleplus () { return browser.$('=Google+') }
   get gError () { return browser.$('div.dEOOab.RxsGPe').getText() }
 
+  // The hard delays are necessary because Google
   set gUsername (val) {
     browser.waitForVisible('input#identifierId')
     // Works on chrome and firefox
@@ -35,6 +51,8 @@ class LoginPage extends Page {
     browser.$('div#identifierNext').click()
     browser.pause(delay)
   }
+
+  // The hard delays are necessary because Google
   set gPassword (val) {
     browser.waitForVisible('input[name="password"]')
     // Works on chrome and firefox

--- a/test/js/pages/login.page.js
+++ b/test/js/pages/login.page.js
@@ -12,7 +12,8 @@ class LoginPage extends Page {
   // Independent of auth source
   get title () { return browser.getTitle() }
 
-  // These are for authentication using Django's built-in auth
+  // These are for authentication using Django's built-in auth on
+  // a local instance; parms.auth = 'django'
   get dUsername () { return browser.$('#id_username') }
   get dPassword () { return browser.$('#id_password') }
   get dLogin () {
@@ -23,11 +24,10 @@ class LoginPage extends Page {
       }
     }
   }
-
   set dUsername (val) { return browser.$('#id_username').setValue(val) }
   set dPassword (val) { return browser.$('#id_password').setValue(val) }
 
-  // These are for authentication using MC's SSO
+  // These are for authentication using MC's SSO; parms.auth = 'mcsso'
   get username () { return browser.$('#login') }
   get password () { return browser.$('#password') }
   get login () { return browser.$('.inputsub') }
@@ -36,7 +36,8 @@ class LoginPage extends Page {
   set username (val) { return browser.$('#login').setValue(val) }
   set password (val) { return browser.$('#password').setValue(val) }
 
-  // These are for authenticating using GoogleAuth on a local instance
+  // These are for authenticating using GoogleAuth on a local instance;
+  // parms.auth = 'google'
   get gUsername () { return browser.$('form').$('input#identifierId') }
   get gPassword () { return browser.$('form').$('input.whsOnd.zHQkBf') }
   get googleplus () { return browser.$('=Google+') }


### PR DESCRIPTION
This PR adds the ability to run the TATS test suite using Django-based authentication