### PR TITLE
Fix filter title on results gas gauge filter list

### DIFF
--- a/indicators/queries.py
+++ b/indicators/queries.py
@@ -638,6 +638,15 @@ class ProgramWithMetricsManager(models.Manager):
                     output_field=models.IntegerField()
                 )
             ), 0)
+        needs_evidence = models.functions.Coalesce(
+            models.Subquery(
+                indicator_subquery_base.filter(
+                    all_results_backed_up=False
+                ).order_by().values('program_id').annotate(
+                    needs_evidence_count=models.Count('id')
+                ).values('needs_evidence_count'),
+                output_field=models.IntegerField()
+            ), 0)
         # targets defined (ALL targets defined)
         targets_defined = models.functions.Coalesce(
             models.Subquery(
@@ -657,6 +666,7 @@ class ProgramWithMetricsManager(models.Manager):
             'reported_results_count': reported_results,
             'reported_results_sum': total_results,
             'results_evidence_count': results_evidence,
+            'needs_evidence_count': needs_evidence,
             'targets_defined_count': targets_defined,
             'indicator_count': indicator_count
         }
@@ -752,6 +762,7 @@ class ProgramWithMetrics(wf_models.Program):
                 'indicator_count': 0,
                 'results_evidence': 0,
                 'results_count': 0,
+                'needs_evidence': 0
             }
         return {
             'reported_results': self.reported_results_count,
@@ -759,6 +770,7 @@ class ProgramWithMetrics(wf_models.Program):
             'indicator_count': self.indicator_count,
             'results_evidence': self.results_evidence_count,
             'results_count': self.reported_results_sum,
+            'needs_evidence': self.needs_evidence_count
         }
 
     @property

--- a/indicators/templatetags/mytags.py
+++ b/indicators/templatetags/mytags.py
@@ -120,6 +120,8 @@ def gauge_tank(context, metric, title, filled_label, unfilled_label, cta, filter
     filled_value = program.metrics[metric]
     results_count = program.metrics['results_count']
     indicator_count = program.metrics['indicator_count']
+    unfilled_value = indicator_count - filled_value
+    filter_title_count = program.metrics['needs_evidence'] if metric == 'results_evidence' else unfilled_value
     denominator = results_count if metric == 'results_evidence' else indicator_count
     filled_percent = int(round(float(filled_value*100)/denominator)) if denominator > 0 else 0
     tick_count = 10
@@ -127,7 +129,7 @@ def gauge_tank(context, metric, title, filled_label, unfilled_label, cta, filter
         'title': title,
         'id_tag': metric,
         'filled_value': filled_value,
-        'unfilled_value': indicator_count - filled_value,
+        'unfilled_value': unfilled_value,
         'indicator_count': indicator_count,
         'results_count': results_count,
         'filled_percent': filled_percent,
@@ -137,6 +139,7 @@ def gauge_tank(context, metric, title, filled_label, unfilled_label, cta, filter
         'ticks': list(range(1,tick_count+1)),
         'cta': cta,
         'filter_title': filter_title,
+        'filter_title_count': filter_title_count
     }
 
 

--- a/templates/indicators/program_indicators_table.html
+++ b/templates/indicators/program_indicators_table.html
@@ -37,7 +37,7 @@ $(document).ready(function() {
         data-reporting="{% if indicator.reporting %}1{% else %}-1{% endif %}" {# whether indicator progress towards targets is reported (min. one target period complete, one result reported) #}
         data-defined-targets="{% if indicator.defined_targets > 0 %}1{% else %}-1{% endif %}" {# whether all targets are defined for this indicator #}
         data-reported-results="{% if indicator.reported_results > 0 %}1{% else %}-1{% endif %}" {# whether any collecteddata is reported for this indicator #}
-        data-has-evidence="{% if indicator.no_missing_evidence %}1{% else %}-1{% endif %}"
+        data-has-evidence="{% if indicator.all_results_backed_up %}1{% else %}-1{% endif %}"
         {# data-has-evidence: 1: indicator has results and all results have evidence, -1: indicator has results and at least one is missing evidence, 0: indicator has no results #}
         data-over-under="{{ indicator.over_under }}"> {# indicator progress towards targets (1: over, 0: within 15% of target, -1: under, "None": non reporting #}
         <td id="id_indicator_name_{{ indicator.id }}">
@@ -79,7 +79,7 @@ $(document).ready(function() {
         data-reporting="{% if indicator.reporting %}1{% else %}-1{% endif %}" {# whether indicator progress towards targets is reported (min. one target period complete, one result reported) #}
         data-defined-targets="{% if indicator.defined_targets > 0 %}1{% else %}-1{% endif %}" {# whether all targets are defined for this indicator #}
         data-reported-results="{% if indicator.reported_results > 0 %}1{% else %}-1{% endif %}" {# whether any collecteddata is reported for this indicator #}
-        data-has-evidence="{% if indicator.reported_results > 0 %}{% if indicator.evidence_count == indicator.reported_results %}1{% else %}-1{% endif %}{% else %}0{% endif %}"
+        data-has-evidence="{% if indicator.all_results_backed_up %}1{% else %}-1{% endif %}"
         {# data-has-evidence: 1: indicator has results and all results have evidence, -1: indicator has results and at least one is missing evidence, 0: indicator has no results #}
         data-over-under="{{ indicator.over_under }}"> {# indicator progress towards targets (1: over, 0: within 15% of target, -1: under, "None": non reporting #}
         <td colspan="6" class="p-0 bg-blue border-0">

--- a/templates/indicators/tags/gauge-tank.html
+++ b/templates/indicators/tags/gauge-tank.html
@@ -4,7 +4,7 @@
 <div class="gauge filter-trigger"
     data-target="{{ id_tag }}"
     data-target-positive="-1"
-    data-list-title="{% blocktrans %}{{ unfilled_value }} indicators {{ filter_title }}{% endblocktrans %}"
+    data-list-title="{% blocktrans %}{{ filter_title_count }} indicators {{ filter_title }}{% endblocktrans %}"
     >
     <h6 class="gauge__title">{% trans title %}</h6>
     <div class="gauge__overview">


### PR DESCRIPTION
Updating filter tag dict to include another element in case of the "results" indicator (since that needs to count indicators, not results for the filter title) - includes back-end query and rough stub of filter tag element (will need rewiring with @axoplasm 's refactor)