### PR TITLE
Remove n+1 DB queries resulting from program/country nav bar

### DIFF
--- a/tola/views.py
+++ b/tola/views.py
@@ -25,7 +25,7 @@ def index(request, selected_country=None):
     """
 
     # Find the active country
-    user = TolaUser.objects.filter(user=request.user)[0]
+    user = request.user.tola_user
     user_countries = getCountry(request.user) # all countries whose programs are available to the user
 
     if selected_country: # from URL

--- a/workflow/templatetags/menu_tag.py
+++ b/workflow/templatetags/menu_tag.py
@@ -13,7 +13,7 @@ def program_menu(context):
         countries = request.user.tola_user.countries.all()
     except AttributeError:
         countries = []
-    programs = Program.objects.filter(funding_status="Funded", country__in=countries).distinct()
+    programs = Program.objects.filter(funding_status="Funded", country__in=countries).prefetch_related('country').distinct()
 
     programs_by_country = OrderedDict((country.country, []) for country in countries)
 


### PR DESCRIPTION
Also use cached TolaUser obj on home page view, because why query again?