### PR TITLE
826 indicator sort order

### DIFF
--- a/indicators/models.py
+++ b/indicators/models.py
@@ -372,9 +372,7 @@ class IndicatorQuerySet(models.QuerySet, IndicatorSortingQSMixin):
 class IndicatorManager(models.Manager, IndicatorSortingManagerMixin):
 
     def get_queryset(self):
-        return IndicatorQuerySet(self.model, using=self._db)\
-            .prefetch_related('program')\
-            .select_related('sector')
+        return IndicatorQuerySet(self.model, using=self._db).select_related('program', 'sector')
 
 
 class Indicator(models.Model):

--- a/indicators/queries.py
+++ b/indicators/queries.py
@@ -7,7 +7,9 @@ from indicators.models import (
     Indicator,
     Level,
     PeriodicTarget,
-    CollectedData
+    CollectedData,
+    IndicatorSortingManagerMixin,
+    IndicatorSortingQSMixin
 )
 from workflow import models as wf_models
 from django.db import models
@@ -391,7 +393,9 @@ def indicator_results_evidence_annotation():
                 ).values('total_results')[:1],
             output_field=models.IntegerField()
         ), 0)
-class MetricsIndicatorQuerySet(models.QuerySet):
+
+
+class MetricsIndicatorQuerySet(models.QuerySet, IndicatorSortingQSMixin):
     """QuerySet for indicators returned for Program Page with annotated metrics"""
 
     def with_annotations(self, *annotations):
@@ -432,7 +436,7 @@ class MetricsIndicatorQuerySet(models.QuerySet):
             qs = qs.select_related('level')
         return qs
 
-class MetricsIndicatorManager(models.Manager):
+class MetricsIndicatorManager(models.Manager, IndicatorSortingManagerMixin):
     def get_queryset(self):
         return MetricsIndicatorQuerySet(self.model, using=self._db)
 
@@ -460,13 +464,13 @@ class MetricsIndicator(Indicator):
             return self.data_count
         return self.collecteddata_set.count()
 
-class IPTTIndicatorQuerySet(models.QuerySet):
+class IPTTIndicatorQuerySet(models.QuerySet, IndicatorSortingQSMixin):
     """This overrides the count method because ONLY_FULL_GROUP_BY errors appear otherwise on this custom query"""
     def count(self):
         return self.values('id').aggregate(total=models.Count('id', distinct=True))['total']
 
 
-class IPTTIndicatorManager(models.Manager):
+class IPTTIndicatorManager(models.Manager, IndicatorSortingManagerMixin):
     """this is the general manager for all IPTT (annotated) indicators - generates totals over LOP"""
 
     def add_labels(self, qs):

--- a/indicators/queries.py
+++ b/indicators/queries.py
@@ -940,7 +940,11 @@ class ProgramWithMetrics(wf_models.Program):
         if self.cached_annotated_indicators is None:
             self.indicator_filters['program'] = self
             program_page_annotations = ['targets', 'results', 'evidence', 'scope', 'table']
-            self.cached_annotated_indicators = MetricsIndicator.objects.filter(**self.indicator_filters).with_annotations(*program_page_annotations)
+            self.cached_annotated_indicators = MetricsIndicator.objects.filter(
+                **self.indicator_filters
+            ).with_annotations(
+                *program_page_annotations
+            ).with_logframe_sorting()
         return self.cached_annotated_indicators
 
 

--- a/indicators/tests/program_metric_tests/indicator_unit/indicator_sorting_unittests.py
+++ b/indicators/tests/program_metric_tests/indicator_unit/indicator_sorting_unittests.py
@@ -8,17 +8,22 @@
             (1, 1.1, 1.2, 1.2.1.1, etc.)
         - else sort alphabetically"""
 
-from factories import indicators_models as factory
+from factories import (
+    indicators_models as factory,
+    workflow_models as w_factory
+)
 from indicators.models import Indicator
 from indicators.queries import (
     MetricsIndicator,
-    IPTTIndicator
+    IPTTIndicator,
+    ProgramWithMetrics
 )
 from django import test
 
-def get_indicator(number):
+def get_indicator(number, program):
     return factory.IndicatorFactory(
-        number=number
+        number=number,
+        program=program
     )
 
 class SortingTestsMixin(object):
@@ -26,37 +31,102 @@ class SortingTestsMixin(object):
     def test_metrics_indicator_manager(self):
         metricsindicators = list(MetricsIndicator.objects.with_logframe_sorting())
         for c, pk in enumerate(self.expected):
-            self.assertEqual(metricsindicators[c].pk, pk)
+            self.assertEqual(
+                metricsindicators[c].pk, pk,
+                "number {0} logframe type {1} logsort_a {2} logsort_b {3}".format(
+                    metricsindicators[c].number,
+                    metricsindicators[c].logsort_type,
+                    metricsindicators[c].logsort_a,
+                    metricsindicators[c].logsort_b,
+                ))
 
     def test_metrics_indicator_queryset(self):
         metricsindicators = list(MetricsIndicator.objects.all().with_logframe_sorting())
         for c, pk in enumerate(self.expected):
-            self.assertEqual(metricsindicators[c].pk, pk)
+            self.assertEqual(metricsindicators[c].pk, pk,
+                "number {0} logframe type {1} logsort_a {2} logsort_b {3}".format(
+                    metricsindicators[c].number,
+                    metricsindicators[c].logsort_type,
+                    metricsindicators[c].logsort_a,
+                    metricsindicators[c].logsort_b,
+                ))
 
     def test_regular_indicator_manager(self):
         metricsindicators = list(Indicator.objects.with_logframe_sorting())
         for c, pk in enumerate(self.expected):
-            self.assertEqual(metricsindicators[c].pk, pk)
+            self.assertEqual(metricsindicators[c].pk, pk,
+                "number {0} logframe type {1} logsort_a {2} logsort_b {3}".format(
+                    metricsindicators[c].number,
+                    metricsindicators[c].logsort_type,
+                    metricsindicators[c].logsort_a,
+                    metricsindicators[c].logsort_b,
+                ))
 
     def test_regular_indicator_queryset(self):
         metricsindicators = list(Indicator.objects.all().with_logframe_sorting())
         for c, pk in enumerate(self.expected):
-            self.assertEqual(metricsindicators[c].pk, pk)
+            self.assertEqual(metricsindicators[c].pk, pk,
+                "number {0} logframe type {1} logsort_a {2} logsort_b {3}".format(
+                    metricsindicators[c].number,
+                    metricsindicators[c].logsort_type,
+                    metricsindicators[c].logsort_a,
+                    metricsindicators[c].logsort_b,
+                ))
+
+    def test_program_page_sorted(self):
+        metricsindicators = list(ProgramWithMetrics.program_page.get(pk=self.program_id).annotated_indicators)
+        for c, pk in enumerate(self.expected):
+            self.assertEqual(metricsindicators[c].pk, pk,
+                "number {0} logframe type {1} logsort_a {2} logsort_b {3}".format(
+                    metricsindicators[c].number,
+                    metricsindicators[c].logsort_type,
+                    metricsindicators[c].logsort_a,
+                    metricsindicators[c].logsort_b,
+                ))
 
 class TestNumericSorting(test.TestCase, SortingTestsMixin):
     def setUp(self):
+        program = w_factory.ProgramFactory()
         self.expected = []
-        for x in range(10):
-            self.expected.append(get_indicator(x+1).id)
+        for x in reversed(range(10)):
+            self.expected.append(get_indicator(x+1, program).id)
+        self.expected = reversed(self.expected)
+        self.program_id = program.id
 
 class TestAlphabeticalSorting(test.TestCase, SortingTestsMixin):
     def setUp(self):
+        program = w_factory.ProgramFactory()
         self.expected = []
-        for x in ['aasdf', 'basdf', 'casdf', 'daasdf', 'e3214', 'f5235']:
-            self.expected.append(get_indicator(x).id)
+        for x in reversed(['aasdf', 'basdf', 'casdf', 'daasdf', 'e3214', 'f5235']):
+            self.expected.append(get_indicator(x, program).id)
+        self.expected = reversed(self.expected)
+        self.program_id = program.id
 
 class TestLogframeSorting(test.TestCase, SortingTestsMixin):
     def setUp(self):
+        program = w_factory.ProgramFactory()
         self.expected = []
-        for x in ['1', '1.1', '1.1.1', '1.2', '2.1.2', '3', '3.2.1.1']:
-            self.expected.append(get_indicator(x).id)
+        for x in reversed(['1', '1.1', '1.1.1', '1.2', '2.1.2', '3', '3.2.1.1', '10.1']):
+            self.expected.append(get_indicator(x, program).id)
+        self.expected = reversed(self.expected)
+        self.program_id = program.id
+
+
+class TestQueryCounts(test.TestCase):
+    def setUp(self):
+        program = w_factory.ProgramFactory()
+        self.expected = []
+        for x in range(10):
+            self.expected.append(get_indicator(x+1, program).id)
+        self.program_id = program.id
+
+    def test_query_counts(self):
+        with self.assertNumQueries(1):
+            metricsindicators = list(Indicator.objects.with_logframe_sorting())
+        with self.assertNumQueries(1):
+            metricsindicators = list(MetricsIndicator.objects.with_logframe_sorting())
+
+    def test_query_counts_from_program(self):
+        program = ProgramWithMetrics.program_page.get(pk=self.program_id)
+        with self.assertNumQueries(1):
+            metricsindicators = list(program.annotated_indicators)

--- a/indicators/tests/program_metric_tests/indicator_unit/indicator_sorting_unittests.py
+++ b/indicators/tests/program_metric_tests/indicator_unit/indicator_sorting_unittests.py
@@ -1,0 +1,62 @@
+"""Test that indicators from any source have a sort order that takes log frame into account
+
+    this is per GH ticket #826, but is almost certainly temporary (log frame support will root this process
+    in data structures, as opposed to string formatting in the indicator number field)
+    Current (temporary) business logic:
+        - if all indicator number fields are strictly numeric: sort numerically
+        - if all indicator number fields are strictly numbers separated by '.': sort as an outline
+            (1, 1.1, 1.2, 1.2.1.1, etc.)
+        - else sort alphabetically"""
+
+from factories import indicators_models as factory
+from indicators.models import Indicator
+from indicators.queries import (
+    MetricsIndicator,
+    IPTTIndicator
+)
+from django import test
+
+def get_indicator(number):
+    return factory.IndicatorFactory(
+        number=number
+    )
+
+class SortingTestsMixin(object):
+
+    def test_metrics_indicator_manager(self):
+        metricsindicators = list(MetricsIndicator.objects.with_logframe_sorting())
+        for c, pk in enumerate(self.expected):
+            self.assertEqual(metricsindicators[c].pk, pk)
+
+    def test_metrics_indicator_queryset(self):
+        metricsindicators = list(MetricsIndicator.objects.all().with_logframe_sorting())
+        for c, pk in enumerate(self.expected):
+            self.assertEqual(metricsindicators[c].pk, pk)
+
+    def test_regular_indicator_manager(self):
+        metricsindicators = list(Indicator.objects.with_logframe_sorting())
+        for c, pk in enumerate(self.expected):
+            self.assertEqual(metricsindicators[c].pk, pk)
+
+    def test_regular_indicator_queryset(self):
+        metricsindicators = list(Indicator.objects.all().with_logframe_sorting())
+        for c, pk in enumerate(self.expected):
+            self.assertEqual(metricsindicators[c].pk, pk)
+
+class TestNumericSorting(test.TestCase, SortingTestsMixin):
+    def setUp(self):
+        self.expected = []
+        for x in range(10):
+            self.expected.append(get_indicator(x+1).id)
+
+class TestAlphabeticalSorting(test.TestCase, SortingTestsMixin):
+    def setUp(self):
+        self.expected = []
+        for x in ['aasdf', 'basdf', 'casdf', 'daasdf', 'e3214', 'f5235']:
+            self.expected.append(get_indicator(x).id)
+
+class TestLogframeSorting(test.TestCase, SortingTestsMixin):
+    def setUp(self):
+        self.expected = []
+        for x in ['1', '1.1', '1.1.1', '1.2', '2.1.2', '3', '3.2.1.1']:
+            self.expected.append(get_indicator(x).id)

--- a/indicators/tests/test_indicator_metrics_unittests.py
+++ b/indicators/tests/test_indicator_metrics_unittests.py
@@ -35,5 +35,7 @@ from program_metric_tests.indicator_unit.over_under_queries_unit_tests import (
 
 from program_metric_tests.indicator_unit.indicator_sorting_unittests import (
     TestNumericSorting,
-    TestAlphabeticalSorting
+    TestAlphabeticalSorting,
+    TestLogframeSorting,
+    TestQueryCounts
 )

--- a/indicators/tests/test_indicator_metrics_unittests.py
+++ b/indicators/tests/test_indicator_metrics_unittests.py
@@ -32,3 +32,8 @@ from program_metric_tests.indicator_unit.reporting_queries_unit_tests import (
 from program_metric_tests.indicator_unit.over_under_queries_unit_tests import (
     TestTargetsActualsOverUnderCorrect
 )
+
+from program_metric_tests.indicator_unit.indicator_sorting_unittests import (
+    TestNumericSorting,
+    TestAlphabeticalSorting
+)


### PR DESCRIPTION
Indicators great and small now have a method with_logframe_sorting() (used by default on program page annotated_indicators return) which sorts:
- numerically
- logframe (1.1.1.1) order
- alphabetically
in that order
tests written to enforce sorting and also query counts