### PR TITLE
Indicator duplication (UI-only, non DB) bugfix

### DIFF
--- a/templates/indicators/indicator_list_modals.html
+++ b/templates/indicators/indicator_list_modals.html
@@ -108,7 +108,7 @@
                 });
 
                 var indicator_number = form.find("#id_number").val();
-                var indicator_name = `${indicator_number} ${form.find("#id_name").val()}`;
+                var indicator_name = `${form.find("#id_name").val()}`;
 
                 if (kpi) {
                     if ($("#id_indicator_name_" + indicator_id + " span.badge").length == 0) {
@@ -123,6 +123,7 @@
                 $("#id_indicator_type_" + indicator_id).text(indicator_type);
                 $("#id_indicator_level_" + indicator_id).text(indicator_level.trim().slice(0, -1));
                 $("#id_indicator_name_" + indicator_id + " a .indicator_name").text(indicator_name);
+                $("#id_indicator_name_" + indicator_id + " a .indicator_number").text(indicator_number);
                 $("#id_indicator_sector_" + indicator_id).text(indicator_sector);
                 $("#id_indicator_unit_" + indicator_id).text(form.find("#id_unit_of_measure").val());
                 $("#id_indicator_baseline_" + indicator_id).text(form.find("#id_baseline").val());

--- a/templates/indicators/program_indicators_table.html
+++ b/templates/indicators/program_indicators_table.html
@@ -49,7 +49,7 @@ $(document).ready(function() {
                 data-toggle="collapse"
                 data-target="#hidden-indicator-{{ indicator.id }}">
                 <i class="fas fa-caret-right"></i>
-                <strong>{{ indicator.number|default_if_none:''}}</strong>
+                <strong class="indicator_number">{{ indicator.number|default_if_none:''}}</strong>
                 <span class="indicator_name">{{ indicator.name}}{#{% if indicator.cached_data_count > 0 %}({{ indicator.cached_data_count }} results){% endif %}#}</span>
             </a>
             {% if indicator.key_performance_indicator %}


### PR DESCRIPTION
separated indicator name and indicator number, plugging indicator number into the <strong> field designated for it
Closes #748 