### PR TITLE
Fixes error thrown when saving an indicator when a program is in 2 co…

### DIFF
--- a/indicators/forms.py
+++ b/indicators/forms.py
@@ -75,7 +75,7 @@ class IndicatorForm(forms.ModelForm):
         self.fields['disaggregation'].queryset = DisaggregationType.objects\
             .filter(country__in=countries, standard=False)
         self.fields['program'].queryset = Program.objects.filter(
-            funding_status="Funded", country__in=countries)
+            funding_status="Funded", country__in=countries).distinct()
         self.fields['objectives'].queryset = Objective.objects.filter(program__id__in=[self.programval.id])
         self.fields['strategic_objectives'].queryset = StrategicObjective.objects.filter(country__in=countries)
         self.fields['approved_by'].queryset = TolaUser.objects.filter(country__in=countries).distinct()


### PR DESCRIPTION
…untries

#875

The form validation called .get(id=pkid) on the programs queryset which returns 2 values, one for each country the program is a part of.