### PR TITLE
100 and 0 should not represent "almost all" or "almost none"

### DIFF
--- a/indicators/tests/program_metric_tests/program_unit/program_qs_metrics_unittests.py
+++ b/indicators/tests/program_metric_tests/program_unit/program_qs_metrics_unittests.py
@@ -172,9 +172,9 @@ class TestTwoProgramsFiveIndicatorsEightResultsFiveEvidence(test.TestCase):
 class TestMultipleProgramsStressTestQSCounts(test.TestCase):
     def setUp(self):
         self.program_ids = []
-        for x in range(10):
+        for _ in range(10):
             program = get_program()
-            for x in range(10):
+            for _ in range(10):
                 ind = get_all_targets_defined_indicator(program)
                 get_data(ind)
                 get_evidence(get_data(ind))


### PR DESCRIPTION
Per description in #543 
Added logic to ensure "100" and "0" percent aren't arrived at by rounding
Closes #543 