### PR TITLE
Fix input values overlapping with % on indicator target form

### DIFF
--- a/scss/_mc_tola_forms.scss
+++ b/scss/_mc_tola_forms.scss
@@ -55,10 +55,6 @@ input[type=number]::-webkit-outer-spin-button {
     position: relative;
     display: inline-block;
     width: 100%;
-    input {
-        padding-right: 15px;
-        width: 100%;
-    }
     &:after {
         position: absolute;
         top: 50%;
@@ -67,7 +63,7 @@ input[type=number]::-webkit-outer-spin-button {
         content:"%";
         right: 20px;
     }
-    .input-value {
+    input.input-value { // adds extra specificity vs. .periodic-target .input-value
         padding-right: 1.60rem;
     }
 }

--- a/scss/tola.scss
+++ b/scss/tola.scss
@@ -87,6 +87,7 @@
 
 /* Local custom CSS and overloads for non-BS libraries */
 @import 'mixins';
+@import 'mc_tola_forms';
 @import 'maps';
 @import 'charts';
 @import 'branding';
@@ -94,7 +95,6 @@
 @import 'sidebar'; // IPTT sidebar
 @import 'misc_utilities'; // small utility/helper selectors that should probably be bootstrap classes
 @import 'custom'; // misc. elements & unsorted selectors
-@import 'mc_tola_forms';
 
 /* Unsorted custom selectors */
 

--- a/scss/tola.scss
+++ b/scss/tola.scss
@@ -87,7 +87,6 @@
 
 /* Local custom CSS and overloads for non-BS libraries */
 @import 'mixins';
-@import 'mc_tola_forms';
 @import 'maps';
 @import 'charts';
 @import 'branding';
@@ -95,6 +94,7 @@
 @import 'sidebar'; // IPTT sidebar
 @import 'misc_utilities'; // small utility/helper selectors that should probably be bootstrap classes
 @import 'custom'; // misc. elements & unsorted selectors
+@import 'mc_tola_forms';
 
 /* Unsorted custom selectors */
 

--- a/tola/static/css/tola.css
+++ b/tola/static/css/tola.css
@@ -7154,74 +7154,6 @@ body > .container {
     width: 1%; }
 
 /* Local custom CSS and overloads for non-BS libraries */
-.help-block {
-  color: #71757b !important;
-  display: block;
-  margin-top: .25rem; }
-
-.form-actions .form-group {
-  margin-bottom: 0; }
-
-.has-crispy-form .tab-content.panel-body {
-  background: white;
-  border: 1px solid #dbdcde;
-  border-top-width: 0;
-  margin-top: 0;
-  padding: 1rem; }
-
-.has-crispy-form .nav-tabs {
-  width: 100%; }
-
-.has-crispy-form .input-group {
-  align-items: center; }
-
-.has-crispy-form #div_id_name {
-  /* overloads jankety overload for select2, see line 481 this file */
-  height: auto; }
-
-.input-group-addon {
-  margin: 0 0.5rem; }
-
-.has-error {
-  color: #c8102e; }
-  .has-error .text-muted {
-    color: inherit !important; }
-
-.border-1px input {
-  border: 1px solid #dbdcde; }
-
-input[type=number] {
-  -moz-appearance: textfield; }
-
-input[type=number]::-webkit-inner-spin-button,
-input[type=number]::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0; }
-
-.input-symbol-percent {
-  position: relative;
-  display: inline-block;
-  width: 100%; }
-  .input-symbol-percent input {
-    padding-right: 15px;
-    width: 100%; }
-  .input-symbol-percent:after {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    margin: auto;
-    content: "%";
-    right: 20px; }
-  .input-symbol-percent .input-value {
-    padding-right: 1.60rem; }
-
-.inputs-in-a-box {
-  background-color: #f5f5f5;
-  border: 0px; }
-
-.hide-askerisks .asteriskField {
-  display: none; }
-
 .map-marker {
   width: 20px;
   height: 20px;
@@ -7904,6 +7836,74 @@ select.listoption_filters {
 .float--right {
   float: right;
   margin-left: 15px; }
+
+.help-block {
+  color: #71757b !important;
+  display: block;
+  margin-top: .25rem; }
+
+.form-actions .form-group {
+  margin-bottom: 0; }
+
+.has-crispy-form .tab-content.panel-body {
+  background: white;
+  border: 1px solid #dbdcde;
+  border-top-width: 0;
+  margin-top: 0;
+  padding: 1rem; }
+
+.has-crispy-form .nav-tabs {
+  width: 100%; }
+
+.has-crispy-form .input-group {
+  align-items: center; }
+
+.has-crispy-form #div_id_name {
+  /* overloads jankety overload for select2, see line 481 this file */
+  height: auto; }
+
+.input-group-addon {
+  margin: 0 0.5rem; }
+
+.has-error {
+  color: #c8102e; }
+  .has-error .text-muted {
+    color: inherit !important; }
+
+.border-1px input {
+  border: 1px solid #dbdcde; }
+
+input[type=number] {
+  -moz-appearance: textfield; }
+
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0; }
+
+.input-symbol-percent {
+  position: relative;
+  display: inline-block;
+  width: 100%; }
+  .input-symbol-percent input {
+    padding-right: 15px;
+    width: 100%; }
+  .input-symbol-percent:after {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    margin: auto;
+    content: "%";
+    right: 20px; }
+  .input-symbol-percent .input-value {
+    padding-right: 1.60rem; }
+
+.inputs-in-a-box {
+  background-color: #f5f5f5;
+  border: 0px; }
+
+.hide-askerisks .asteriskField {
+  display: none; }
 
 /* Unsorted custom selectors */
 

--- a/tola/static/css/tola.css
+++ b/tola/static/css/tola.css
@@ -7154,6 +7154,71 @@ body > .container {
     width: 1%; }
 
 /* Local custom CSS and overloads for non-BS libraries */
+.help-block {
+  color: #71757b !important;
+  display: block;
+  margin-top: .25rem; }
+
+.form-actions .form-group {
+  margin-bottom: 0; }
+
+.has-crispy-form .tab-content.panel-body {
+  background: white;
+  border: 1px solid #dbdcde;
+  border-top-width: 0;
+  margin-top: 0;
+  padding: 1rem; }
+
+.has-crispy-form .nav-tabs {
+  width: 100%; }
+
+.has-crispy-form .input-group {
+  align-items: center; }
+
+.has-crispy-form #div_id_name {
+  /* overloads jankety overload for select2, see line 481 this file */
+  height: auto; }
+
+.input-group-addon {
+  margin: 0 0.5rem; }
+
+.has-error {
+  color: #c8102e; }
+  .has-error .text-muted {
+    color: inherit !important; }
+
+.border-1px input {
+  border: 1px solid #dbdcde; }
+
+input[type=number] {
+  -moz-appearance: textfield; }
+
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0; }
+
+.input-symbol-percent {
+  position: relative;
+  display: inline-block;
+  width: 100%; }
+  .input-symbol-percent:after {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    margin: auto;
+    content: "%";
+    right: 20px; }
+  .input-symbol-percent input.input-value {
+    padding-right: 1.60rem; }
+
+.inputs-in-a-box {
+  background-color: #f5f5f5;
+  border: 0px; }
+
+.hide-askerisks .asteriskField {
+  display: none; }
+
 .map-marker {
   width: 20px;
   height: 20px;
@@ -7836,74 +7901,6 @@ select.listoption_filters {
 .float--right {
   float: right;
   margin-left: 15px; }
-
-.help-block {
-  color: #71757b !important;
-  display: block;
-  margin-top: .25rem; }
-
-.form-actions .form-group {
-  margin-bottom: 0; }
-
-.has-crispy-form .tab-content.panel-body {
-  background: white;
-  border: 1px solid #dbdcde;
-  border-top-width: 0;
-  margin-top: 0;
-  padding: 1rem; }
-
-.has-crispy-form .nav-tabs {
-  width: 100%; }
-
-.has-crispy-form .input-group {
-  align-items: center; }
-
-.has-crispy-form #div_id_name {
-  /* overloads jankety overload for select2, see line 481 this file */
-  height: auto; }
-
-.input-group-addon {
-  margin: 0 0.5rem; }
-
-.has-error {
-  color: #c8102e; }
-  .has-error .text-muted {
-    color: inherit !important; }
-
-.border-1px input {
-  border: 1px solid #dbdcde; }
-
-input[type=number] {
-  -moz-appearance: textfield; }
-
-input[type=number]::-webkit-inner-spin-button,
-input[type=number]::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0; }
-
-.input-symbol-percent {
-  position: relative;
-  display: inline-block;
-  width: 100%; }
-  .input-symbol-percent input {
-    padding-right: 15px;
-    width: 100%; }
-  .input-symbol-percent:after {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    margin: auto;
-    content: "%";
-    right: 20px; }
-  .input-symbol-percent .input-value {
-    padding-right: 1.60rem; }
-
-.inputs-in-a-box {
-  background-color: #f5f5f5;
-  border: 0px; }
-
-.hide-askerisks .asteriskField {
-  display: none; }
 
 /* Unsorted custom selectors */
 


### PR DESCRIPTION
`.periodic-target .input-value.` in _custom.scss was overriding `.input-symbol-percent .input-value` in _mc_tola_forms.scss, which is why the right padding was incorrect.

Switching the order such that the forms CSS comes after custom CSS matches the ordering that used to exist in app.css, which is why this works on production.

#873