### PR TITLE
903 reporting period modal end date

### DIFF
--- a/indicators/templatetags/mytags.py
+++ b/indicators/templatetags/mytags.py
@@ -269,5 +269,6 @@ def program_complete(context):
         'program.start_date': program.start_date,
         'program.end_date': program.end_date,
         'program.reporting_period_start': program.reporting_period_start,
+        'program.reporting_period_end': program.reporting_period_end,
         'program.percent_complete': program.percent_complete,
     }

--- a/templates/indicators/indicator_reportingperiod_modal.html
+++ b/templates/indicators/indicator_reportingperiod_modal.html
@@ -429,7 +429,8 @@
             $("#id_reporting_start_date").val(formatDate(origRptStart));
             try{
                 // Need to do this so datepicker doesn't use an old value that it has stored from a prior interaction
-                $("#id_reporting_start_date").datepicker("setDate", new Date(origRptStart));
+                let resetStartDate = processDateString(origRptStart);
+                $("#id_reporting_start_date").datepicker("setDate", resetStartDate);
             }
             catch(error){}
         }
@@ -440,7 +441,8 @@
             $("#id_reporting_end_date").val(formatDate(origRptEnd));
             try {
                 // Need to do this so datepicker doesn't use an old value that it has stored from a prior interaction
-                $("#id_reporting_end_date").datepicker("setDate", new Date(origRptEnd));
+                let resetEndDate = processDateString(origRptEnd);
+                $("#id_reporting_end_date").datepicker("setDate", resetEndDate);
             }
             catch(error){}
         }


### PR DESCRIPTION
@KennyMonster On the reset, feeding the ISO string directly into `new Date` was causing the problem.  

I also took a look at the backend to see if validation was needed there, but I think it's not.  If the start field is disabled, the value shouldn't get sent to server anyway and the pre-existing start-date shouldn't be altered.