### PR TITLE
Remove more links to the Indicator page that was ripped out in 357b9c7b

### DIFF
--- a/indicators/tests/iptt_sample_data/response1.html
+++ b/indicators/tests/iptt_sample_data/response1.html
@@ -78,7 +78,7 @@
 
                         <ul class="navbar-nav">
                             <li class="nav-item pr-2 mr-3">
-                                <a class="nav-link" href="/indicators/home/0/0/0/">Indicators</a>
+                                <a class="nav-link" href="#">Indicators</a>
                             </li>
                             <li class="nav-item dropdown pr-2 mr-3">
                                 <a class="nav-link dropdown-toggle" href="#" id="navbarBrowse" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Browse</a>

--- a/indicators/views/views_indicators.py
+++ b/indicators/views/views_indicators.py
@@ -792,8 +792,7 @@ class CollectedDataCreate(CreateView):
             return HttpResponse(data)
 
         messages.success(self.request, _('Success, Data Created!'))
-        redirect_url = '/indicators/home/0/0/0/#hidden-%s' % \
-                       str(self.kwargs['program'])
+        redirect_url = reverse_lazy('program_page', args=(self.kwargs['program'], 0, 0))
         return HttpResponseRedirect(redirect_url)
 
 
@@ -913,8 +912,7 @@ class CollectedDataUpdate(UpdateView):
             return HttpResponse(data)
 
         messages.success(self.request, _('Success, Data Updated!'))
-        redirect_url = '/indicators/home/0/0/0/#hidden-%s' \
-                       % str(getIndicator.program.id)
+        redirect_url = reverse_lazy('program_page', args=(getIndicator.program.id, 0, 0))
 
         return HttpResponseRedirect(redirect_url)
 

--- a/templates/bootstrap4.html
+++ b/templates/bootstrap4.html
@@ -77,9 +77,6 @@
                             <a class="dropdown-item" href="/workflow/stakeholder_list/0/0">Stakeholders</a>
                         </div>
                     </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="/indicators/home/0/0/0">Indicators</a>
-                    </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" id="navbarFormlibraryDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Form Library</a>
                         <div class="dropdown-menu" aria-labelledby="navbarFormlibraryDropdown">

--- a/templates/indicators/collecteddata_form.html
+++ b/templates/indicators/collecteddata_form.html
@@ -1,12 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% block bread_crumb %}
-<ol class="breadcrumb">
-  <li><a href="/indicators/home/0/0/0/#hidden-{{ self.program }}">{% trans "Indicators" %}</a></li>
-  <li class="active">{% trans "Output Form" %}</li>
-</ol>
 
-{% endblock %}
 {% block page_title %}{% trans "Collected Indicator Data" %} {% endblock %}
 
 {% block content %}

--- a/templates/indicators/filter.html
+++ b/templates/indicators/filter.html
@@ -162,7 +162,7 @@
         var programId = $("#program_filter_value").data('programid');
         var indicatorId = $("#indicator_filter_value").data('indicatorid');
         var typeId = $("#type_filter_value").data('typeid');
-        var url = '/indicators/home/';
+        var url = '/program/';
 
         url += (parseInt(programId) >= 0 ? programId : 0) + '/';
         url += (parseInt(indicatorId) >= 0 ? indicatorId : 0) + '/';

--- a/templates/indicators/grid_report.html
+++ b/templates/indicators/grid_report.html
@@ -2,21 +2,14 @@
 {% load i18n %}
 
 {% block title %}{% trans "Indicator Plan" %} | {% endblock %}
-{% block bread_crumb %}
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="/indicators/home/0/0/0/">{% trans "Indicators" %}</a></li>
-        <li class="active breadcrumb-item">{% trans "Indicator Plan" %}</li>
-    </ol>
-</nav>
-{% endblock bread_crumb %}
+
 {% load render_table from django_tables2 %}
 
 {% block page_title %}{% trans "Indicator Plan" %}{% endblock %}
 
 {% block content %}
 
-<h3>{{ getProgram.gaitid }} - {{ getProgram.name }}</h3>
+<h3><a href="{% url 'program_page' getProgram.id 0 0 %}">{{ getProgram.gaitid }} - {{ getProgram.name }}</a></h3>
 
     <!-- Table -->
     <!--

--- a/templates/indicators/home.html
+++ b/templates/indicators/home.html
@@ -15,9 +15,9 @@
     <span class="caret"></span>
     </button>
     <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
-        <li role="presentation"><a role="menuitem" tabindex="-1" href="/indicators/home/0/0/0/"> {% trans "-- All --" %}</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="/"> {% trans "-- All --" %}</a></li>
     {% for program in getPrograms %}
-        <li role="presentation"><a role="menuitem" tabindex="-1" href="/indicators/home/{{ program.id }}/0/0/">{{ program.gaitid}} - {{ program.name }}</a></li>
+        <li role="presentation"><a role="menuitem" tabindex="-1" href="/program/{{ program.id }}/0/0/">{{ program.gaitid}} - {{ program.name }}</a></li>
     {% endfor %}
     </ul>
     <a href="/indicators/indicator" class="btn btn-large btn-success">{% trans "New Indicator" %}</a>

--- a/templates/indicators/indicator_create.html
+++ b/templates/indicators/indicator_create.html
@@ -3,14 +3,6 @@
 {% block bodyclasses %}has-crispy-form{% endblock %}
 {% block title %}{% trans "Add indicator" %} | {% endblock %}
 {% block page_title %}{% trans "Add indicator" %}{% endblock %}
-{% block bread_crumb %}
-<nav aria-label="breadcrumb">
-    <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a href="/indicators/home/0/0/0/">{% trans "Indicators" %}</a></li>
-      <li class="active breadcrumb-item">{% trans "Add indicator" %}</li>
-    </ol>
-</nav>
-{% endblock %}
 
 
 {% block extra_js_in_body %}

--- a/templates/report_base.html
+++ b/templates/report_base.html
@@ -71,7 +71,6 @@
                     <li class="dropdown">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">Indicators<b class="caret"></b></a>
                         <ul class="dropdown-menu">
-                            <li><a href="/indicators/home/0/0/0/"><span class="glyphicon glyphicon-dashboard"></span> Indicator Planning</a></li>
                             <li><a href="/indicators/collecteddata/0/0/"><span class="glyphicon glyphicon-th-list"></span> Indicator Data</a></li>
                             <li><a href="/indicators/report/0/0/0/"><span class="glyphicon glyphicon-check"></span> Indicator Library</a></li>
                         </ul>


### PR DESCRIPTION
Some of the pages touched here are dead/unreachable

One reference still exists in test/js/pages/target.page.js which relates to a test which probably also needs to be removed by someone who knows what's up with these tests.

Closes #980