### PR TITLE
1018 program page redirect

### DIFF
--- a/indicators/tests/test_program_page_access_redirects.py
+++ b/indicators/tests/test_program_page_access_redirects.py
@@ -6,28 +6,27 @@ from factories import (
 )
 from django.shortcuts import reverse
 
+
 class TestProgramPageRedirects(test.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(TestProgramPageRedirects, cls).setUpClass()
-        cls.country_a = w_factories.CountryFactory(
+    def setUp(self):
+        self.country_a = w_factories.CountryFactory(
             country="Test A",
             code="TA"
         )
-        cls.country_b = w_factories.CountryFactory(
+        self.country_b = w_factories.CountryFactory(
             code="TB"
         )
-        cls.program_a = w_factories.ProgramFactory()
-        cls.program_a.country.set([cls.country_a])
-        cls.program_a.save()
-        cls.program_b = w_factories.ProgramFactory()
-        cls.program_b.country.set([cls.country_b])
-        cls.program_b.save()
-        cls.tola_user = w_factories.TolaUserFactory()
-        cls.tola_user.countries.set([cls.country_a])
-        cls.tola_user.save()
-        cls.user = cls.tola_user.user
-        cls.client = test.Client()
+        self.program_a = w_factories.ProgramFactory()
+        self.program_a.country.set([self.country_a])
+        self.program_a.save()
+        self.program_b = w_factories.ProgramFactory()
+        self.program_b.country.set([self.country_b])
+        self.program_b.save()
+        self.tola_user = w_factories.TolaUserFactory()
+        self.tola_user.countries.set([self.country_a])
+        self.tola_user.save()
+        self.user = self.tola_user.user
+        self.client = test.Client()
 
     def test_unit_test_user_has_access_to_program_in_country(self):
         self.assertTrue(self.tola_user.has_access(program_id=self.program_a.pk))

--- a/indicators/tests/test_program_page_access_redirects.py
+++ b/indicators/tests/test_program_page_access_redirects.py
@@ -34,7 +34,7 @@ class TestProgramPageRedirects(test.TestCase):
 
     def test_user_is_able_to_access_program_in_country(self):
         """User should get a program page back for a program in one of their countries"""
-        self.client.force_login(user=self.user)
+        self.client.force_login(self.user)
         url = reverse('program_page', kwargs={'program_id': self.program_a.id,
                                               'indicator_id': 0,
                                               'type_id': 0})
@@ -46,7 +46,7 @@ class TestProgramPageRedirects(test.TestCase):
 
     def test_user_is_redirected_from_program_not_in_country(self):
         """User should be redirected to home page for a program not in one of their countries"""
-        self.client.force_login(user=self.user)
+        self.client.force_login(self.user)
         url = reverse('program_page', kwargs={'program_id': self.program_b.id,
                                               'indicator_id': 0,
                                               'type_id': 0})

--- a/indicators/tests/test_program_page_access_redirects.py
+++ b/indicators/tests/test_program_page_access_redirects.py
@@ -1,0 +1,67 @@
+"""A program page accessed by URL should redirect the user to home if they do not have access to that program"""
+
+from django import test
+from factories import (
+    workflow_models as w_factories
+)
+from django.shortcuts import reverse
+
+class TestProgramPageRedirects(test.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestProgramPageRedirects, cls).setUpClass()
+        cls.country_a = w_factories.CountryFactory(
+            country="Test A",
+            code="TA"
+        )
+        cls.country_b = w_factories.CountryFactory(
+            code="TB"
+        )
+        cls.program_a = w_factories.ProgramFactory()
+        cls.program_a.country.set([cls.country_a])
+        cls.program_a.save()
+        cls.program_b = w_factories.ProgramFactory()
+        cls.program_b.country.set([cls.country_b])
+        cls.program_b.save()
+        cls.tola_user = w_factories.TolaUserFactory()
+        cls.tola_user.countries.set([cls.country_a])
+        cls.tola_user.save()
+        cls.user = cls.tola_user.user
+        cls.client = test.Client()
+
+    def test_unit_test_user_has_access_to_program_in_country(self):
+        self.assertTrue(self.tola_user.has_access(program_id=self.program_a.pk))
+
+    def test_user_is_able_to_access_program_in_country(self):
+        """User should get a program page back for a program in one of their countries"""
+        self.client.force_login(user=self.user)
+        url = reverse('program_page', kwargs={'program_id': self.program_a.id,
+                                              'indicator_id': 0,
+                                              'type_id': 0})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_unit_test_user_has_no_access_to_program_out_of_country(self):
+        self.assertFalse(self.tola_user.has_access(program_id=self.program_b.pk))
+
+    def test_user_is_redirected_from_program_not_in_country(self):
+        """User should be redirected to home page for a program not in one of their countries"""
+        self.client.force_login(user=self.user)
+        url = reverse('program_page', kwargs={'program_id': self.program_b.id,
+                                              'indicator_id': 0,
+                                              'type_id': 0})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+
+    def test_anonymous_user_is_redirected_from_program_page(self):
+        """Anonymous user should be redirected to home page for any program page"""
+        url = reverse('program_page', kwargs={'program_id': self.program_a.id,
+                                              'indicator_id': 0,
+                                              'type_id': 0})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        url = reverse('program_page', kwargs={'program_id': self.program_b.id,
+                                              'indicator_id': 0,
+                                              'type_id': 0})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)

--- a/indicators/views/views_indicators.py
+++ b/indicators/views/views_indicators.py
@@ -1449,6 +1449,8 @@ class ProgramPage(ListView):
     def get(self, request, *args, **kwargs):
         # countries = request.user.tola_user.countries.all()
         program_id = int(self.kwargs['program_id'])
+        if request.user.is_anonymous or not request.user.tola_user.has_access(program_id=program_id):
+            return HttpResponseRedirect('/')
         unannotated_program = Program.objects.only(
             'reporting_period_start', 'reporting_period_end',
             'start_date', 'end_date'

--- a/workflow/models.py
+++ b/workflow/models.py
@@ -185,6 +185,14 @@ class TolaUser(models.Model):
         self.active_country = country
         super(TolaUser, self).save()
 
+    # generic has access function (countries, programs, etc.?  currently program_id implemented):
+    def has_access(self, **kwargs):
+        if 'program_id' in kwargs:
+            return Program.objects.filter(
+                country__in=self.countries.all()
+                ).filter(pk=kwargs.get('program_id')).exists()
+        return False
+
 
 class TolaBookmarks(models.Model):
     user = models.ForeignKey(TolaUser, related_name='tolabookmark', verbose_name=_("User"))


### PR DESCRIPTION
This closes #1018 
Tests written (ensures that when accessing specifically the program page:
a user is redirected to home if they are anonymous (not logged in)
a user is redirected to home if they are logged in but do not have that program's country in their countries list
a user is not redirected to home if they are logged in and have that program's country in their countries list

Abstracted the "has_access" logic to the TolaUser model so Parthenon can adjust as needed to support partner access