### PR TITLE
Prevent TolaUser __unicode__ returning None which breaks the Django A…

### DIFF
--- a/workflow/models.py
+++ b/workflow/models.py
@@ -157,7 +157,8 @@ class TolaUser(models.Model):
         ordering = ('name',)
 
     def __unicode__(self):
-        return self.name
+        # Returning None breaks the Django Admin on models with a FK to TolaUser
+        return self.name or u''
 
     @property
     def countries_list(self):


### PR DESCRIPTION
…dmin

If a model as a FK to TolaUser, and TolaUser.name is None, the Django Admin form breaks. This should never happen thanks to other fixes, but fixing this as well just in case.