### PR TITLE
Closes #1091 percentage signs

### DIFF
--- a/templates/indicators/indicator_form_helper.html
+++ b/templates/indicators/indicator_form_helper.html
@@ -186,13 +186,13 @@
                                 <!-- {% render_field form.lop_target class+="form-control" %} -->
                                 <span id="span_{{ form.lop_target.id_for_label }}">
                                     <input type="number"
-                                            name="{{ form.lop_target.name }}"
-                                            id="{{ form.lop_target.id_for_label }}"
-                                            class="form-control"
-                                            min="1"
-                                            {% if form.lop_target.value != None %} value="{{ form.lop_target.value|stringformat:'s' }}"{% endif %}
-                                            required
-                                            onblur="this.checkValidity();">
+                                        name="{{ form.lop_target.name }}"
+                                        id="{{ form.lop_target.id_for_label }}"
+                                        class="form-control"
+                                        min="1"
+                                        {% if form.lop_target.value != None %} value="{{ form.lop_target.value|stringformat:'s' }}"{% endif %}
+                                        required
+                                        onblur="this.checkValidity();">
                                 </span>
                                 <small class="form-text text-muted">{{ form.lop_target.help_text }}</small>
                                 <span id="validation_id_lop_target" class="has-error"></span>
@@ -397,11 +397,17 @@
 <script>
 
     /*
-    Adds/removes the percent symbol to the LOP_TARGET and BASELINE fields
+    Adds/removes the percent symbol in several places
     */
     function togglePercentSymbol(){
         // toggle % sign on sum values
         $(".periodic-targets__sum__value").toggleClass('input-symbol-percent')
+
+        // toggle % sign on LoP target input
+        $("#span_id_lop_target").toggleClass('input-symbol-percent')
+
+        // toggle % sign on baseline input
+        $("#span_id_baseline").toggleClass('input-symbol-percent')
 
         // toggle % sign to target inputs
         $("#periodic_targets_table input[data-periodictarget]").each(function(index, element) {
@@ -513,17 +519,20 @@
             $("#id_span_label_targets_sum").text("{% trans 'Sum of targets'|escapejs %}");
             $("#id_span_targets_sum").text(targetsSum);
             $("#id_span_targtsaggregate_percent_sign").text("");
-            $("#id_span_loptarget_percent_sign").text("");
+            $("#id_span_loptarget_percent_sign").text(""); // May be absent now?
         }
         else{
-            $("#id_span_loptarget_percent_sign").text("%");
+            $("#id_span_loptarget_percent_sign").text("%"); // May be absent now?
         }
     }
 
     $( document ).ready(function() {
         var unit_of_measure_type = $("#id_unit_of_measure_type_1").is(":checked") ? 2 : 1;
+        console.log(unit_of_measure_type);
         if (unit_of_measure_type == 2){
             show_hide_cummulative_inputs('percent')
+            $('#span_id_lop_target').addClass('input-symbol-percent');
+            $('#span_id_baseline').addClass('input-symbol-percent');
         }
         else {
             show_hide_cummulative_inputs('number')

--- a/templates/indicators/indicator_form_helper.html
+++ b/templates/indicators/indicator_form_helper.html
@@ -518,11 +518,6 @@
             var targetsSum = getTargetsSumAndNum()[0];
             $("#id_span_label_targets_sum").text("{% trans 'Sum of targets'|escapejs %}");
             $("#id_span_targets_sum").text(targetsSum);
-            $("#id_span_targtsaggregate_percent_sign").text("");
-            $("#id_span_loptarget_percent_sign").text(""); // May be absent now?
-        }
-        else{
-            $("#id_span_loptarget_percent_sign").text("%"); // May be absent now?
         }
     }
 


### PR DESCRIPTION
Adds percentage signs to two inputs (LoP target and Baseline) for Percentage indicators.

All 100% jQuery of course.

Also removed some stale listeners for the old-school method for adding percent signs.

Fun note: `targets` is still misspelled `targts` in many places!

```
(venv) [paul@Aphelocoma TolaActivity]$ ack targts
indicators/tests/iptt_sample_data/response1.html
1749:            var remove_missing_targts_link = jsondata["remove_missing_targts_link"];
1780:            if (remove_missing_targts_link == true) {

indicators/views/views_indicators.py
589:                    remove_missing_targts_link = False
591:                    remove_missing_targts_link = True
593:                remove_missing_targts_link = True
616:                "remove_missing_targts_link": remove_missing_targts_link

templates/indicators/indicator_form_common_js.html
378:            var remove_missing_targts_link = jsondata["remove_missing_targts_link"];
404:            if (remove_missing_targts_link == true) {
```