### PR TITLE
Evidence DB migration + UI update

### DIFF
--- a/indicators/fixtures/one_program_home_page.yaml
+++ b/indicators/fixtures/one_program_home_page.yaml
@@ -52,7 +52,7 @@
     periodic_target: 1
     date_collected: '2015-05-01'
     achieved: 550
-    evidence: 1
+    evidence_url: 'http://test_evidence_url'
 - model: indicators.indicator
   pk: 2
   fields:
@@ -80,7 +80,7 @@
     periodic_target: 2
     date_collected: '2015-01-10'
     achieved: 450
-    evidence: 2
+    evidence_url: 'http://test_evidence_url_2'
 - model: indicators.result
   pk: 3
   fields:

--- a/indicators/management/commands/create_qa_programs.py
+++ b/indicators/management/commands/create_qa_programs.py
@@ -251,9 +251,9 @@ class Command(BaseCommand):
 
                             if null_level == self.NULL_LEVELS['EVIDENCE']:
                                 continue
-                            document = Documentation.objects.create(
-                                program=program, name='Doc for RSid {}'.format(rs.id), url='http://my/doc/here/')
-                            rs.evidence = document
+
+                            rs.evidence_name = 'Evidence link for RSid {}'.format(rs.id)
+                            rs.evidence_url = 'http://my/evidence/here/'
                             rs.save()
 
                         indicator.lop_target = lop_target
@@ -396,9 +396,9 @@ class Command(BaseCommand):
 
                 if q in [5, 6]:
                     continue
-                document = Documentation.objects.create(
-                    program=program, name='Doc for RSid {}'.format(rs.id), url='http://my/doc/here/')
-                rs.evidence = document
+
+                rs.evidence_name = 'Evidence link for RSid {}'.format(rs.id)
+                rs.evidence_url = 'http://my/evidence/here/'
                 rs.save()
 
             indicator.lop_target = lop_target

--- a/indicators/migrations/0047_evidence_field_and_migration.py
+++ b/indicators/migrations/0047_evidence_field_and_migration.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def copy_evidence_from_documents(apps, schema_editor):
+    Result = apps.get_model('indicators', 'Result')
+    for result in Result.objects.filter(evidence__isnull=False).select_related('evidence'):
+        doc = result.evidence
+        # either of these fields may be NULL on the Documentation, so force to empty str
+        result.evidence_name = doc.name or ''
+        result.evidence_url = doc.url or ''
+        result.save()
+
+
+def reverse_migration(apps, schema_editor):
+    """Allow the reverse migration to happen"""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('indicators', '0046_merge_20190115_1415'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='historicalresult',
+            name='evidence_name',
+            field=models.CharField(blank=True, max_length=135),
+        ),
+        migrations.AddField(
+            model_name='historicalresult',
+            name='evidence_url',
+            field=models.CharField(blank=True, max_length=255),
+        ),
+        migrations.AddField(
+            model_name='result',
+            name='evidence_name',
+            field=models.CharField(blank=True, max_length=135),
+        ),
+        migrations.AddField(
+            model_name='result',
+            name='evidence_url',
+            field=models.CharField(blank=True, max_length=255),
+        ),
+
+        # data migration
+        migrations.RunPython(copy_evidence_from_documents, reverse_code=reverse_migration),
+    ]

--- a/indicators/models.py
+++ b/indicators/models.py
@@ -1053,6 +1053,7 @@ class Result(models.Model):
         _("Comment/Explanation"), max_length=255, blank=True, null=True,
         help_text=" ")
 
+    # Deprecated - see evidence_name/evidence_url
     evidence = models.ForeignKey(
         Documentation, null=True, blank=True, on_delete=models.SET_NULL,
         verbose_name=_("Evidence Document or Link"), help_text=" ")
@@ -1061,12 +1062,17 @@ class Result(models.Model):
         TolaUser, blank=True, null=True, on_delete=models.SET_NULL, verbose_name=_("Originated By"),
         related_name="approving_data", help_text=" ")
 
+    # Deprecated
     tola_table = models.ForeignKey(
         TolaTable, blank=True, null=True, on_delete=models.SET_NULL, verbose_name=_("TolaTable"), help_text=" ")
 
+    # Deprecated
     update_count_tola_table = models.BooleanField(
         verbose_name=_("Would you like to update the achieved total with the \
         row count from TolaTables?"), default=False, help_text=" ")
+
+    evidence_name = models.CharField(max_length=135, blank=True)
+    evidence_url = models.CharField(max_length=255, blank=True)
 
     create_date = models.DateTimeField(null=True, blank=True, help_text=" ")
     edit_date = models.DateTimeField(null=True, blank=True, help_text=" ")

--- a/indicators/queries/indicators_queries.py
+++ b/indicators/queries/indicators_queries.py
@@ -183,8 +183,8 @@ def indicator_results_evidence_annotation():
         models.Subquery(
             Result.objects.filter(
                 indicator=models.OuterRef('pk')
-                ).filter(
-                    models.Q(evidence__isnull=False) | models.Q(tola_table__isnull=False)
+                ).exclude(
+                    evidence_url=''
                 ).order_by().values('indicator').annotate(
                     total_results=models.Count('id')
                 ).values('total_results')[:1],

--- a/indicators/queries/iptt_queries.py
+++ b/indicators/queries/iptt_queries.py
@@ -286,7 +286,8 @@ class WithMetricsIndicatorManager(IPTTIndicatorManager):
         data_with_evidence = Result.objects.filter(
             models.Q(indicator_id=models.OuterRef('pk')) |
             models.Q(periodic_target__indicator_id=models.OuterRef('pk')),
-            models.Q(evidence__isnull=False) | models.Q(tola_table__isnull=False)
+        ).exclude(
+            evidence_url=''
         ).order_by().values('indicator_id')
         qs = qs.annotate(
             evidence_count=models.functions.Coalesce(

--- a/indicators/queries/program_queries.py
+++ b/indicators/queries/program_queries.py
@@ -376,8 +376,8 @@ def program_evidence_annotation():
     """annotates a program with the count of results for any of the program's indicators which have evidence"""
     rs = Result.objects.filter(
         indicator__program_id=models.OuterRef('pk')
-    ).filter(
-        models.Q(evidence__isnull=False) | models.Q(tola_table__isnull=False)
+    ).exclude(
+        evidence_url=''
     ).order_by().values('indicator__program').annotate(evidence_count=models.Count('pk')).values('evidence_count')[:1]
     return models.functions.Coalesce(
         models.Subquery(

--- a/indicators/serializers.py
+++ b/indicators/serializers.py
@@ -4,38 +4,6 @@ from workflow.models import Program
 from indicators.models import PeriodicTarget, Result, Indicator, Level
 from django.db.models import Sum
 
-class ResultSerializer(serializers.ModelSerializer):
-    cumsum = serializers.SerializerMethodField()
-
-    class Meta:
-        model = Result
-        fields = ('id', 'program', 'indicator', 'periodic_target', 'achieved',
-                  'cumsum', 'date_collected', 'evidence', 'tola_table',
-                  'agreement', 'complete', 'site', 'create_date', 'edit_date')
-
-    def get_cumsum(self, obj):
-        total_achieved = Result.objects.filter(
-            indicator=obj.indicator,
-            create_date__lt=obj.create_date).aggregate(Sum('achieved'))['achieved__sum']
-
-        if total_achieved is None:
-            total_achieved = 0
-        total_achieved = total_achieved + obj.achieved
-        return total_achieved
-
-
-class PeriodictargetSerializer(serializers.ModelSerializer):
-    result_set = ResultSerializer(many=True, read_only=True)
-    result__achieved__sum = serializers.IntegerField()
-    cumulative_sum = serializers.IntegerField()
-
-    class Meta:
-        model = PeriodicTarget
-        fields = ('id', 'indicator', 'period', 'target', 'start_date',
-                  'end_date', 'customsort', 'create_date', 'edit_date',
-                  'result_set', 'result__achieved__sum',
-                  'cumulative_sum')
-
 
 class LevelSerializer(serializers.ModelSerializer):
     """

--- a/indicators/tests/program_metric_tests/functional_tests/home_page_integration_tests.py
+++ b/indicators/tests/program_metric_tests/functional_tests/home_page_integration_tests.py
@@ -52,11 +52,10 @@ class HomePageQueryStressTest(test.TestCase):
                     lop_target=100,
                     program=program
                 )
-                evidence = w_factories.DocumentationFactory(program=program)
                 i_factories.ResultFactory(
                     indicator=indicator,
                     achieved=50,
-                    evidence=evidence
+                    evidence_url='http://test_evidence_url'
                 )
             for _ in range(2):
                 indicator = i_factories.IndicatorFactory(

--- a/indicators/tests/program_metric_tests/functional_tests/program_page_integration_tests.py
+++ b/indicators/tests/program_metric_tests/functional_tests/program_page_integration_tests.py
@@ -68,8 +68,7 @@ def do_add_reported_result(indicator, collect_date, program):
     )
 
 def do_add_evidence(result, program):
-    doc = w_factories.DocumentationFactory(program=program)
-    result.evidence = doc
+    result.evidence_url = 'http://test_evidence_url'
     result.save()
 
 

--- a/indicators/tests/program_metric_tests/indicator_unit/results_with_evidence_count_queries_unit_tests.py
+++ b/indicators/tests/program_metric_tests/indicator_unit/results_with_evidence_count_queries_unit_tests.py
@@ -1,9 +1,7 @@
 """Results With Evidence Queries for Program Page Indicator List
 
 Business Rules:
- - count = # of results with either
-    -an evidence FK to a Documentation model or
-    -a tolatable fk to a TolaTable model
+ - count = # of results with wn evidence_url that is non-empty
 """
 
 from factories import (
@@ -30,16 +28,9 @@ class EvidenceMixin(object):
         return MetricsIndicator.objects.with_annotations('evidence').get(pk=indicator.pk)
 
     def add_evidence(self, data):
-        evidence = w_factories.DocumentationFactory()
-        data.evidence = evidence
+        data.evidence_url = 'http://test_evidence_url'
         data.save()
-        return evidence
 
-    def add_tolatable(self, data):
-        tolatable = i_factories.TolaTableFactory()
-        data.tola_table = tolatable
-        data.save()
-        return tolatable
 
 @test.tag('evidence', 'metrics', 'core')
 class TestResultswithEvidenceCount(test.TestCase, EvidenceMixin):
@@ -65,46 +56,12 @@ class TestResultswithEvidenceCount(test.TestCase, EvidenceMixin):
         annotated_indicator = self.get_annotated_indicator(indicator)
         self.assertEqual(annotated_indicator.results_with_evidence_count, 1)
 
-    def test_one_data_one_tolatable(self):
-        """one result and one tolatable should have results_with_evidence_count of 1"""
-        indicator = self.get_indicator()
-        data = self.add_result(indicator)
-        self.add_tolatable(data)
-        annotated_indicator = self.get_annotated_indicator(indicator)
-        self.assertEqual(annotated_indicator.results_with_evidence_count, 1)
-
-class TestResultsMixedEvidenceTypes(test.TestCase, EvidenceMixin):
-    """results_with_evidence_count should match number of results with evidence or tolatables"""
-
-    def test_one_of_each_type(self):
-        """one evidence and one tolatable should show results_with_evidence_count of 2"""
+    def test_one_data_two_evidence(self):
+        """one result and two evidence should have results_with_evidence_count of 2"""
         indicator = self.get_indicator()
         data = self.add_result(indicator)
         self.add_evidence(data)
         data2 = self.add_result(indicator)
-        self.add_tolatable(data2)
+        self.add_evidence(data2)
         annotated_indicator = self.get_annotated_indicator(indicator)
         self.assertEqual(annotated_indicator.results_with_evidence_count, 2)
-
-    def test_mixed_evidence_types_multiple_indicators(self):
-        """for multiple indicators, results_with_evidence_count should be 11"""
-        expected = [0, 3, 0, 2, 5]
-        none_indicator = self.get_indicator()
-        self.add_result(none_indicator)
-        three_indicator = self.get_indicator()
-        self.add_evidence(self.add_result(three_indicator))
-        self.add_evidence(self.add_result(three_indicator))
-        self.add_evidence(self.add_result(three_indicator))
-        self.get_indicator()
-        two_indicator = self.get_indicator()
-        self.add_tolatable(self.add_result(two_indicator))
-        self.add_tolatable(self.add_result(two_indicator))
-        five_indicator = self.get_indicator()
-        self.add_evidence(self.add_result(five_indicator))
-        self.add_tolatable(self.add_result(five_indicator))
-        self.add_evidence(self.add_result(five_indicator))
-        self.add_tolatable(self.add_result(five_indicator))
-        self.add_evidence(self.add_result(five_indicator))
-        for count, indicator in zip(expected, MetricsIndicator.objects.with_annotations('evidence').order_by('pk')):
-            self.assertEqual(count, indicator.results_with_evidence_count)
-        

--- a/indicators/tests/program_metric_tests/program_unit/program_metrics_queries_unit_tests.py
+++ b/indicators/tests/program_metric_tests/program_unit/program_metrics_queries_unit_tests.py
@@ -33,7 +33,6 @@ class ProgramMetricsBase(test.TestCase):
         self.indicators = []
         self.targets = []
         self.data = []
-        self.documents = []
 
     def get_indicator(self, frequency=Indicator.LOP):
         indicator = i_factories.IndicatorFactory(
@@ -63,10 +62,8 @@ class ProgramMetricsBase(test.TestCase):
         return target
 
     def add_evidence(self, data):
-        documentation = w_factories.DocumentationFactory()
-        data.evidence = documentation
+        data.evidence_url = 'http://test_evidence_url'
         data.save()
-        self.documents.append(documentation)
 
 
 class TestIndicatorCounts(ProgramMetricsBase):
@@ -397,9 +394,6 @@ class TestProgramWithEvidenceQueries(ProgramMetricsBase):
                 "One indicator with 1 result and 1 evidence should be counted as 1 with evidence, got {0}".format(
                     program.metrics['results_evidence'])
             )
-            for doc in self.documents:
-                doc.delete()
-            self.documents = []
             for datum in self.data:
                 datum.delete()
             self.data = []
@@ -465,8 +459,7 @@ class TestIndicatorReportingEdgeCases(test.TestCase):
         )
 
     def add_evidence(self, result):
-        document = w_factories.DocumentationFactory()
-        result.evidence = document
+        result.evidence_url = 'http://test_evidence_url'
         result.save()
 
     def results_count_asserts(self, indicator_count, with_results_count, results_count):

--- a/indicators/tests/program_metric_tests/program_unit/program_qs_metrics_unittests.py
+++ b/indicators/tests/program_metric_tests/program_unit/program_qs_metrics_unittests.py
@@ -47,8 +47,7 @@ def get_data(indicator):
     )
 
 def get_evidence(data):
-    ev = w_factories.DocumentationFactory()
-    data.evidence=ev
+    data.evidence_url = 'http://test_evidence_url'
     data.save()
 
 class TestTwoProgramsBothDefined(test.TestCase):

--- a/indicators/tests/test_indicator_metrics_unittests.py
+++ b/indicators/tests/test_indicator_metrics_unittests.py
@@ -20,7 +20,6 @@ from program_metric_tests.indicator_unit.has_reported_results_queries_unit_tests
 
 from program_metric_tests.indicator_unit.results_with_evidence_count_queries_unit_tests import (
     TestResultswithEvidenceCount,
-    TestResultsMixedEvidenceTypes
 )
 
 from program_metric_tests.indicator_unit.reporting_queries_unit_tests import (

--- a/templates/indicators/result_table.html
+++ b/templates/indicators/result_table.html
@@ -69,10 +69,15 @@
                         {% endwith %}
                     </td>
                     <td class="td--stretch">
-                        {% if cdata.evidence %}
-                            {% if cdata.evidence.url %}<a href="{{cdata.evidence.url}}" target="_blank">{% endif %}
-                            {{ cdata.evidence|default_if_none:"" }}
-                            {% if cdata.evidence.url %}</a>{% endif %}
+{#                        {% if cdata.evidence %}#}
+{#                            {% if cdata.evidence.url %}<a href="{{cdata.evidence.url}}" target="_blank">{% endif %}#}
+{#                            {{ cdata.evidence|default_if_none:"" }}#}
+{#                            {% if cdata.evidence.url %}</a>{% endif %}#}
+{#                        {% endif %}#}
+                        {% if cdata.evidence_url %}
+                            <a href="{{cdata.evidence_url}}" target="_blank">
+                            {{ cdata.evidence_name|default:cdata.evidence_url }}
+                            </a>
                         {% endif %}
                         {% if cdata.complete %}
                             <a href="{% url 'projectcomplete_update' cdata.complete.id %}"
@@ -83,7 +88,6 @@
                                target="_blank"
                                class="btn-link"><i class="fas fa-clipboard"></i> {% trans "View project" %}</a>
                         {% endif %}
-                        {% comment {{ cdata.complete|default_if_none:cdata.agreement|default_if_none:'' }} %} {% endcomment %}
                         {% if cdata.tola_table %}
                             cdata.tola_table
                             <a href="{{ cdata.tola_table.detail_url }}" target="_blank">{{ cdata.tola_table }}</a>
@@ -98,6 +102,7 @@
                 </tr>
                 {% endif %}
             {% endfor %}{# for cdata in pt.result_set #}
+
         </tr>
         {% endfor %}{# for pt in periodictargets #}
 


### PR DESCRIPTION
This PR covers redefining evidence on Results including

* New DB fields on Result
* Data migration to migration Documentation name/url fields to Result fields
* Update to program metric queries for "results missing evidence"
* Display of new evidence fields in results table on program page

Closes #1040
Closes #1053 
Closes #1054