### PR TITLE
Fix validation on reporting dates

### DIFF
--- a/indicators/queries.py
+++ b/indicators/queries.py
@@ -928,6 +928,17 @@ class ProgramWithMetrics(wf_models.Program):
             ),
         }
 
+    @property
+    def reporting_period_correct(self):
+        """a bug allowed reporting period dates not on the first/last of the month into the db, this lets us check and
+        advise users to handle it"""
+        if not self.reporting_period_start or not self.reporting_period_end or self.reporting_period_start.day != 1:
+            return False
+        next_day = self.reporting_period_end + datetime.timedelta(days=1)
+        if next_day.day != 1:
+            return False
+        return True
+
     @cached_property
     def all_targets_defined_for_all_indicators(self):
         """note: we define a program with 0 indicators as _not_ having all targets defined"""

--- a/indicators/tests/test_program_metrics_unittests.py
+++ b/indicators/tests/test_program_metrics_unittests.py
@@ -22,7 +22,8 @@ from program_metric_tests.program_unit.program_metrics_queries_unit_tests import
 from program_metric_tests.program_unit.program_reporting_count_unit_tests import (
     TestSingleNonReportingIndicator,
     TestSingleReportingIndicator,
-    TestMixedReportingAndNonIndicators
+    TestMixedReportingAndNonIndicators,
+    TestProgramReportingPeriodCorrect
 )
 
 from program_metric_tests.program_unit.program_scope_queries_unit_tests import (

--- a/templates/home.html
+++ b/templates/home.html
@@ -70,17 +70,13 @@
                         </ul>
                     {% endif %}
                 </div>
-                {% if program.reporting_period_start and program.reporting_period_end and program.reporting_period_correct %}
+                {% if program.reporting_period_start and program.reporting_period_end %}
                     {% program_complete %}
                 {% endif %}
             </div>
             <div class="card-body">
-                {% if not program.reporting_period_start or not program.reporting_period_end or not program.reporting_period_correct %}
-                    {% if not program.reporting_period_correct %}
-                    <p>{% trans "There is a problem with your program's" %}
-                    {% else %}
+                {% if not program.reporting_period_start or not program.reporting_period_end %}
                     <p>{% trans "Before adding indicators and performance results, we need to know your program's" %}
-                    {% endif %}
                         <a
                             id="id_link_reporting_period_{{ program.id }}"
                             class=""

--- a/templates/home.html
+++ b/templates/home.html
@@ -70,13 +70,17 @@
                         </ul>
                     {% endif %}
                 </div>
-                {% if program.reporting_period_start and program.reporting_period_end %}
+                {% if program.reporting_period_start and program.reporting_period_end and program.reporting_period_correct %}
                     {% program_complete %}
                 {% endif %}
             </div>
             <div class="card-body">
-                {% if not program.reporting_period_start or not program.reporting_period_end %}
-                    <p>Before adding indicators and performance results, we need to know your program's
+                {% if not program.reporting_period_start or not program.reporting_period_end or not program.reporting_period_correct %}
+                    {% if not program.reporting_period_correct %}
+                    <p>{% trans "There is a problem with your program's" %}
+                    {% else %}
+                    <p>{% trans "Before adding indicators and performance results, we need to know your program's" %}
+                    {% endif %}
                         <a
                             id="id_link_reporting_period_{{ program.id }}"
                             class=""
@@ -88,16 +92,16 @@
                             data-rptstart="{{ program.reporting_period_start }}"
                             data-rptend="{{ program.reporting_period_end }}"
                             data-target="#id_reporting_period_modal"
-                            >reporting start and end dates.</a>
+                            >{% trans "reporting start and end dates." %}</a>
                     </p>
                 {% elif program.metrics.indicator_count == 0 %}
-                    <h4>No indicators have been entered for this program.</h4>
+                    <h4>{% trans "No indicators have been entered for this program." %}</h4>
                     <a href="{% url 'indicator_create' program.id %}" role="button" class="btn-link btn-add"><i class="fas fa-plus-circle"></i> {% trans "Add indicator" %}</a>
                 {% elif program.metrics.targets_defined == 0 %}
                     <div class="float--left">
                         <i class="gauge__icon gauge__icon--error fas fa-frown"></i>
                     </div>
-                    <h4>All indicators are missing targets.</h4>
+                    <h4>{% trans "All indicators are missing targets." %}</h4>
                     <p>Visit the <a href="{% url "program_page" program.id 0 0 %}">Program page</a> to set up targets.
                 {% else %}
                     <div class="status__gauges">

--- a/templates/indicators/indicator_reportingperiod_modal.html
+++ b/templates/indicators/indicator_reportingperiod_modal.html
@@ -393,23 +393,26 @@
         }
         else{
              reporting_period_submitting = true;
-            $.post($(this).attr('action'), $(this).serialize(), function(data){
-
-                $('#id_reporting_period_modal').modal("hide")
-                // var program_id = data.program_id;
-                // var modalLink = $(`a[data-program="${program_id}"]`);
-                // modalLink.data("rptstart", data.rptstart);
-                // modalLink.data("rptend", data.rptend);
-                // createAlert(
-                //   "success",
-                //   "{% trans 'Success. Reporting period changes were saved.'|escapejs %}",
-                //   true,
-                //   "#div-id-reportingperiod-alert");
-
+            $.post({
+                url: $(this).attr('action'),
+                data: $(this).serialize(),
+                success: function(data){
+                    $('#id_reporting_period_modal').modal("hide")
+                    },
+                suppressErrors: true
             }).fail(function(data) {
+                let msg = "{% trans 'There was a problem saving your changes.'|escapejs %}";
+                if (typeof(data.responseJSON.failmsg) !== 'undefined') {
+                    msg = data.responseJSON.failmsg;
+                }
+                if (typeof(data.responseJSON.failfields) !== 'undefined' && data.responseJSON.failfields.length > 0) {
+                    for (let i = 0; i<data.responseJSON.failfields.length; i++) {
+                        $('[name="' + data.responseJSON.failfields[i] + '"]').addClass('is-invalid');
+                    }
+                }
                 createAlert(
                   "danger",
-                  "{% trans 'There was a problem saving your changes.'|escapejs %}",
+                  msg,
                   false,
                   "#div-id-reportingperiod-alert");
             });

--- a/tola/static/js/app.js
+++ b/tola/static/js/app.js
@@ -12,19 +12,23 @@ $( document )
         $('#ajaxloading').hide();
     })
     .ajaxError(function( event, jqxhr, settings, thrownError ) {
-        if (jqxhr.readyState === 4) {
-            // HTTP error (can be checked by XMLHttpRequest.status and XMLHttpRequest.statusText)
-            // TODO: Give better error mssages based on HTTP status code
-            let errorStr = `${jqxhr.status}: ${jqxhr.statusText}`;
-            notifyError(js_context.strings.serverError, errorStr);
-        }
-        else if (jqxhr.readyState === 0) {
-            // Network error (i.e. connection refused, access denied due to CORS, etc.)
-            notifyError(js_context.strings.networkError, js_context.strings.networkErrorTryAgain);
-        }
-        else {
-            // something weird is happening
-            notifyError(js_context.strings.unknownNetworkError, jqxhr.statusText);
+        if (settings.suppressErrors === true) {
+            //do nothing
+        } else {
+            if (jqxhr.readyState === 4) {
+                // HTTP error (can be checked by XMLHttpRequest.status and XMLHttpRequest.statusText)
+                // TODO: Give better error mssages based on HTTP status code
+                let errorStr = `${jqxhr.status}: ${jqxhr.statusText}`;
+                notifyError(js_context.strings.serverError, errorStr);
+            }
+            else if (jqxhr.readyState === 0) {
+                // Network error (i.e. connection refused, access denied due to CORS, etc.)
+                notifyError(js_context.strings.networkError, js_context.strings.networkErrorTryAgain);
+            }
+            else {
+                // something weird is happening
+                notifyError(js_context.strings.unknownNetworkError, jqxhr.statusText);
+            }
         }
     });
 

--- a/workflow/tests/test_program_dates_validation.py
+++ b/workflow/tests/test_program_dates_validation.py
@@ -1,0 +1,107 @@
+"""Ensure reporting_period_start and reporting_period_end can only be set with first and last of the month dates
+respectively"""
+
+import datetime
+import json
+from django import test
+from django.shortcuts import reverse
+from factories import workflow_models as w_factories
+from workflow.views import reportingperiod_update
+from workflow.models import Program
+
+class TestReportingPeriodDatesValidate(test.TestCase):
+    def setUp(self):
+        self.factory = test.RequestFactory()
+
+    def test_reporting_period_updates_with_good_start_data(self):
+        program = w_factories.ProgramFactory(
+            reporting_period_start=datetime.date(2015, 1, 1),
+            reporting_period_end=datetime.date(2017, 12, 31)
+        )
+        request = self.factory.post(reverse('reportingperiod_update', kwargs={'pk': program.pk}),
+                                    {'reporting_period_start': '2016-01-01',
+                                     'reporting_period_end': '2017-12-31'})
+        response = reportingperiod_update(request, program.pk)
+        self.assertEqual(json.loads(response.content)['msg'], 'success')
+        self.assertEqual(response.status_code, 200)
+        refreshed = Program.objects.get(pk=program.pk)
+        self.assertEqual(refreshed.reporting_period_start, datetime.date(2016, 1, 1))
+        self.assertEqual(refreshed.reporting_period_end, datetime.date(2017, 12, 31))
+
+    def test_reporting_period_updates_with_good_end_data(self):
+        program = w_factories.ProgramFactory(
+            reporting_period_start=datetime.date(2015, 1, 1),
+            reporting_period_end=datetime.date(2017, 12, 31)
+        )
+        request = self.factory.post(reverse('reportingperiod_update', kwargs={'pk': program.pk}),
+                                    {'reporting_period_start': '2015-01-01',
+                                     'reporting_period_end': '2016-12-31'})
+        response = reportingperiod_update(request, program.pk)
+        self.assertEqual(json.loads(response.content)['msg'], 'success')
+        self.assertEqual(response.status_code, 200)
+        refreshed = Program.objects.get(pk=program.pk)
+        self.assertEqual(refreshed.reporting_period_start, datetime.date(2015, 1, 1))
+        self.assertEqual(refreshed.reporting_period_end, datetime.date(2016, 12, 31))
+
+    def test_reporting_period_updates_with_good_both_data(self):
+        program = w_factories.ProgramFactory(
+            reporting_period_start=datetime.date(2015, 1, 1),
+            reporting_period_end=datetime.date(2017, 12, 31)
+        )
+        request = self.factory.post(reverse('reportingperiod_update', kwargs={'pk': program.pk}),
+                                    {'reporting_period_start': '2014-02-01',
+                                     'reporting_period_end': '2018-10-31'})
+        response = reportingperiod_update(request, program.pk)
+        self.assertEqual(json.loads(response.content)['msg'], 'success')
+        self.assertEqual(response.status_code, 200)
+        refreshed = Program.objects.get(pk=program.pk)
+        self.assertEqual(refreshed.reporting_period_start, datetime.date(2014, 2, 1))
+        self.assertEqual(refreshed.reporting_period_end, datetime.date(2018, 10, 31))
+
+    def test_reporting_period_does_not_update_with_bad_start_data(self):
+        program = w_factories.ProgramFactory(
+            reporting_period_start=datetime.date(2015, 1, 1),
+            reporting_period_end=datetime.date(2017, 12, 31)
+        )
+        request = self.factory.post(reverse('reportingperiod_update', kwargs={'pk': program.pk}),
+                                    {'reporting_period_start': '2015-02-15',
+                                     'reporting_period_end': '2017-12-31'})
+        response = reportingperiod_update(request, program.pk)
+        self.assertEqual(json.loads(response.content)['msg'], 'fail')
+        self.assertEqual(len(json.loads(response.content)['failmsg']), 1)
+        self.assertEqual(response.status_code, 422)
+        refreshed = Program.objects.get(pk=program.pk)
+        self.assertEqual(refreshed.reporting_period_start, datetime.date(2015, 1, 1))
+        self.assertEqual(refreshed.reporting_period_end, datetime.date(2017, 12, 31))
+
+    def test_reporting_period_does_not_update_with_bad_end_data(self):
+        program = w_factories.ProgramFactory(
+            reporting_period_start=datetime.date(2015, 1, 1),
+            reporting_period_end=datetime.date(2017, 12, 31)
+        )
+        request = self.factory.post(reverse('reportingperiod_update', kwargs={'pk': program.pk}),
+                                    {'reporting_period_start': '2015-01-01',
+                                     'reporting_period_end': '2017-10-15'})
+        response = reportingperiod_update(request, program.pk)
+        self.assertEqual(json.loads(response.content)['msg'], 'fail')
+        self.assertEqual(len(json.loads(response.content)['failmsg']), 1)
+        self.assertEqual(response.status_code, 422)
+        refreshed = Program.objects.get(pk=program.pk)
+        self.assertEqual(refreshed.reporting_period_start, datetime.date(2015, 1, 1))
+        self.assertEqual(refreshed.reporting_period_end, datetime.date(2017, 12, 31))
+
+    def test_reporting_period_does_not_update_with_bad_both_data(self):
+        program = w_factories.ProgramFactory(
+            reporting_period_start=datetime.date(2015, 1, 1),
+            reporting_period_end=datetime.date(2017, 12, 31)
+        )
+        request = self.factory.post(reverse('reportingperiod_update', kwargs={'pk': program.pk}),
+                                    {'reporting_period_start': '2015-02-15',
+                                     'reporting_period_end': '2017-10-15'})
+        response = reportingperiod_update(request, program.pk)
+        self.assertEqual(json.loads(response.content)['msg'], 'fail')
+        self.assertEqual(len(json.loads(response.content)['failmsg']), 2)
+        self.assertEqual(response.status_code, 422)
+        refreshed = Program.objects.get(pk=program.pk)
+        self.assertEqual(refreshed.reporting_period_start, datetime.date(2015, 1, 1))
+        self.assertEqual(refreshed.reporting_period_end, datetime.date(2017, 12, 31))


### PR DESCRIPTION
 Prevent users from setting programs start dates to other than first of the month and end dates to other than last of the month