### PR TITLE
adjusted logic so "target of 0 to date" indicators are counted as "un…

### DIFF
--- a/indicators/queries/utils.py
+++ b/indicators/queries/utils.py
@@ -241,6 +241,11 @@ def indicator_reporting_annotation():
             lop_actual_progress__isnull=True,
             then=models.Value(False)
         ),
+        models.When(
+            # if the target over all to date is 0, can't calculate over/under
+            lop_target_progress=0,
+            then=models.Value(False)
+        ),
         default=models.Value(True),
         output_field=models.BooleanField()
     )

--- a/indicators/tests/test_results_view_queries.py
+++ b/indicators/tests/test_results_view_queries.py
@@ -328,7 +328,7 @@ class ResultsTestBase:
     def test_result_rows_percents_values(self):
         for count, pt_row in enumerate(self.results_indicator.annotated_targets):
             if count < len(self.expected_result_values) and self.target_values[count] == 0:
-                expected = 0
+                expected = None
             elif count < len(self.expected_result_values):
                 expected = round(float(self.expected_result_values[count])/self.target_values[count], 2)
             else:


### PR DESCRIPTION
…available" for scope purposes