### PR TITLE
2096 double carets

### DIFF
--- a/indicators/templates/forms/widgets/collapsed_groups.html
+++ b/indicators/templates/forms/widgets/collapsed_groups.html
@@ -1,9 +1,9 @@
 {% spaceless %}{% for subwidget in widget.subwidgets %}
     <fieldset>
         <a href="#" id="{{ widget.name }}_toggle_{{ forloop.counter0 }}" class="is-accordion-toggle btn btn-link"
-           data-toggle="collapse" data-target="#{{ widget.name }}_inputs_{{ forloop.counter0 }}"
-           aria-expanded="false" aria-controls="{{ widget.name }}_inputs_{{ forloop.counter0 }}">
-            <i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>{{ subwidget.title }}
+            data-toggle="collapse" data-target="#{{ widget.name }}_inputs_{{ forloop.counter0 }}"
+            aria-expanded="true" aria-controls="{{ widget.name }}_inputs_{{ forloop.counter0 }}">
+            <i class="fas fa-caret-down"></i>{{ subwidget.title }}
         </a>
         <div class="collapse show" id="{{ widget.name }}_inputs_{{ forloop.counter0 }}">
             {% include subwidget.template_name with widget=subwidget %}

--- a/indicators/tests/form_tests/indicator_custom_fields.py
+++ b/indicators/tests/form_tests/indicator_custom_fields.py
@@ -37,9 +37,9 @@ class TestGroupedMultipleChoiceField(test.TestCase):
             field.widget.render('name', []),
             """<fieldset>
                 <a href="#" id="name_toggle_0" class="is-accordion-toggle btn btn-link"
-                data-toggle="collapse" data-target="#name_inputs_0" aria-expanded="false"
-                aria-controls="name_inputs_0">
-                    <i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>Test Name
+                data-toggle="collapse" data-target="#name_inputs_0"
+                aria-expanded="true" aria-controls="name_inputs_0">
+                    <i class="fas fa-caret-down"></i>Test Name
                 </a>
                 <div class="collapse show" id="name_inputs_0">
                     <div>
@@ -68,9 +68,9 @@ class TestGroupedMultipleChoiceField(test.TestCase):
             field.widget.render('name', []),
             """<fieldset>
                 <a href="#" id="name_toggle_0" class="is-accordion-toggle btn btn-link"
-                data-toggle="collapse" data-target="#name_inputs_0" aria-expanded="false"
+                data-toggle="collapse" data-target="#name_inputs_0" aria-expanded="true"
                 aria-controls="name_inputs_0">
-                    <i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>Test Name
+                    <i class="fas fa-caret-down"></i>Test Name
                 </a>
                 <div class="collapse show" id="name_inputs_0">
                     <div>
@@ -112,8 +112,8 @@ class TestGroupedMultipleChoiceField(test.TestCase):
             field.widget.render('grouped_field_name', []),
             """<fieldset>
             <a href="#" id="grouped_field_name_toggle_0" class="is-accordion-toggle btn btn-link"
-             data-toggle="collapse" data-target="#grouped_field_name_inputs_0" aria-expanded="false"
-             aria-controls="grouped_field_name_inputs_0"><i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>{0}</a>
+             data-toggle="collapse" data-target="#grouped_field_name_inputs_0" aria-expanded="true"
+             aria-controls="grouped_field_name_inputs_0"><i class="fas fa-caret-down"></i>{0}</a>
              <div class="collapse show" id="grouped_field_name_inputs_0"><div>
                 <div class="form-check"><input class="form-check-input" type="checkbox"
                  name="grouped_field_name_0" value="100" id="grouped_field_name_0_check_0">
@@ -130,8 +130,8 @@ class TestGroupedMultipleChoiceField(test.TestCase):
                 </div></div>
             </fieldset><fieldset>
             <a href="#" id="grouped_field_name_toggle_1" class="is-accordion-toggle btn btn-link"
-             data-toggle="collapse" data-target="#grouped_field_name_inputs_1" aria-expanded="false"
-             aria-controls="grouped_field_name_inputs_1"><i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>{1}</a>
+             data-toggle="collapse" data-target="#grouped_field_name_inputs_1" aria-expanded="true"
+             aria-controls="grouped_field_name_inputs_1"><i class="fas fa-caret-down"></i>{1}</a>
              <div class="collapse show" id="grouped_field_name_inputs_1"><div>
                 <div class="form-check"><input class="form-check-input" type="checkbox"
                  name="grouped_field_name_1" value="21" id="grouped_field_name_1_check_0">
@@ -153,8 +153,8 @@ class TestGroupedMultipleChoiceField(test.TestCase):
             str(form['group_field']),
             """<fieldset>
             <a href="#" id="group_field_toggle_0" class="is-accordion-toggle btn btn-link"
-             data-toggle="collapse" data-target="#group_field_inputs_0" aria-expanded="false"
-             aria-controls="group_field_inputs_0"><i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>One</a>
+             data-toggle="collapse" data-target="#group_field_inputs_0" aria-expanded="true"
+             aria-controls="group_field_inputs_0"><i class="fas fa-caret-down"></i>One</a>
              <div class="collapse show" id="group_field_inputs_0"><div>
                 <div class="form-check"><input class="form-check-input" type="checkbox"
                  name="group_field_0" value="1" id="group_field_0_check_0" checked>
@@ -165,8 +165,8 @@ class TestGroupedMultipleChoiceField(test.TestCase):
                 </div></div>
             </fieldset><fieldset>
             <a href="#" id="group_field_toggle_1" class="is-accordion-toggle btn btn-link"
-             data-toggle="collapse" data-target="#group_field_inputs_1" aria-expanded="false"
-             aria-controls="group_field_inputs_1"><i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>Two</a>
+             data-toggle="collapse" data-target="#group_field_inputs_1" aria-expanded="true"
+             aria-controls="group_field_inputs_1"><i class="fas fa-caret-down"></i>Two</a>
              <div class="collapse show" id="group_field_inputs_1"><div>
                 <div class="form-check"><input class="form-check-input" type="checkbox"
                  name="group_field_1" value="3" id="group_field_1_check_0">

--- a/indicators/tests/form_tests/indicator_form_disaggregations_unittests.py
+++ b/indicators/tests/form_tests/indicator_form_disaggregations_unittests.py
@@ -90,8 +90,8 @@ class TestIndicatorCreateFormDisaggregations(test.TestCase):
             str(form['grouped_disaggregations']),
             """<fieldset>
             <a href="#" id="grouped_disaggregations_toggle_0" class="is-accordion-toggle btn btn-link"
-             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="false"
-             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>
+             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="true"
+             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-down"></i>
              Global disaggregations</a>
              <div class="collapse show" id="grouped_disaggregations_inputs_0"><div class="scroll-box-200">
                 <div class="form-check"><input class="form-check-input" type="checkbox"
@@ -113,8 +113,8 @@ class TestIndicatorCreateFormDisaggregations(test.TestCase):
             str(form['grouped_disaggregations']),
             """<fieldset>
             <a href="#" id="grouped_disaggregations_toggle_0" class="is-accordion-toggle btn btn-link"
-             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="false"
-             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>
+             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="true"
+             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-down"></i>
              Global disaggregations</a>
              <div class="collapse show" id="grouped_disaggregations_inputs_0"><div class="scroll-box-200">
                 <div class="form-check"><input class="form-check-input" type="checkbox"
@@ -135,8 +135,8 @@ class TestIndicatorCreateFormDisaggregations(test.TestCase):
             str(form['grouped_disaggregations']),
             """<fieldset>
             <a href="#" id="grouped_disaggregations_toggle_0" class="is-accordion-toggle btn btn-link"
-             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="false"
-             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>
+             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="true"
+             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-down"></i>
              Testland disaggregations</a>
              <div class="collapse show" id="grouped_disaggregations_inputs_0"><div class="scroll-box-200">
                 <div class="form-check"><input class="form-check-input" type="checkbox"
@@ -164,8 +164,8 @@ class TestIndicatorCreateFormDisaggregations(test.TestCase):
             str(form['grouped_disaggregations']),
             """<fieldset>
             <a href="#" id="grouped_disaggregations_toggle_0" class="is-accordion-toggle btn btn-link"
-             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="false"
-             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>
+             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="true"
+             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-down"></i>
              Testland disaggregations</a>
              <div class="collapse show" id="grouped_disaggregations_inputs_0"><div class="scroll-box-200">
                 <div class="form-check"><input class="form-check-input" type="checkbox"
@@ -198,8 +198,8 @@ class TestIndicatorCreateFormDisaggregations(test.TestCase):
             str(form['grouped_disaggregations']),
             """<fieldset>
             <a href="#" id="grouped_disaggregations_toggle_0" class="is-accordion-toggle btn btn-link"
-             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="false"
-             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>
+             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="true"
+             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-down"></i>
              Testland disaggregations</a>
              <div class="collapse show" id="grouped_disaggregations_inputs_0"><div class="scroll-box-200">
                 <div class="form-check"><input class="form-check-input" type="checkbox"
@@ -540,8 +540,8 @@ class TestIndicatorUpdateFormDisaggregations(test.TestCase):
             str(form['grouped_disaggregations']),
             """<fieldset>
             <a href="#" id="grouped_disaggregations_toggle_0" class="is-accordion-toggle btn btn-link"
-             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="false"
-             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-right"></i><i class="fas fa-caret-down"></i>
+             data-toggle="collapse" data-target="#grouped_disaggregations_inputs_0" aria-expanded="true"
+             aria-controls="grouped_disaggregations_inputs_0"><i class="fas fa-caret-down"></i>
              Global disaggregations</a>
              <div class="collapse show" id="grouped_disaggregations_inputs_0"><div class="scroll-box-200">
                 <div class="form-check"><input class="form-check-input" type="checkbox" checked disabled

--- a/templates/indicators/indicator_form_modal.html
+++ b/templates/indicators/indicator_form_modal.html
@@ -200,7 +200,9 @@
                             <span id="validation_id_justification" class="has-error"></span>
                         </div>
 
-                        {{ form.grouped_disaggregations }}
+                        <div class="form-group" id="div_id_grouped_disaggregations">
+                            {{ form.grouped_disaggregations }}
+                        </div>
 
                         <div class="form-group" id="div_id_indicator_type">
                             <label for="id_indicator_type" class="">{{ form.indicator_type.label }} </label>
@@ -449,7 +451,7 @@
                     </button>
                     {# Translators: close a modal throwing away any changes to the form #}
                     <button type="button" id="id_cancel_btn" class="btn btn-reset">{% trans 'Cancel' %}</button>
-                </div>    
+                </div>
                 {% endif %}
             {% form_guidance form %}
             </div>
@@ -502,6 +504,16 @@
         recordTrackedFieldsSnapshot(true);
 
         allowModalToClose = false;
+
+        // disaggregation accordion
+        $('.is-accordion-toggle').on('click', function(e) {
+            let icon = $(this).find("svg");
+            if (icon.hasClass('fa-caret-right')) {
+                icon.attr('class', 'fa-caret-down');
+            } else {
+                icon.attr('class', 'fa-caret-right');
+            }
+        });
     });
 
     // Use BS multiselect widget where needed

--- a/tola/settings/test.py
+++ b/tola/settings/test.py
@@ -31,6 +31,7 @@ DATABASES = {
             'charset': 'utf8mb4',
         },
         "HOST": "localhost",
+        "USER": "root",
         "PORT": "",
     },
 }


### PR DESCRIPTION
Fixes #2096. Uses the jQuery expando pattern from elsewhere in the indicator modal. 

But maybe it should be react?