### PR TITLE
2082 targets validation bugfixes

### DIFF
--- a/indicators/forms.py
+++ b/indicators/forms.py
@@ -390,7 +390,10 @@ class IndicatorForm(forms.ModelForm):
 
 class ResultForm(forms.ModelForm):
     rationale = forms.CharField(required=False)
-    achieved = NonLocalizedDecimalField(decimal_places=2, localize=True)
+    achieved = NonLocalizedDecimalField(
+        decimal_places=2, localize=True,
+        # Translators: This is a result that was actually achieved, versus one that was planned.
+        label=_('Actual value'))
 
     class Meta:
         model = Result
@@ -402,9 +405,7 @@ class ResultForm(forms.ModelForm):
         }
         labels = {
             'site': _('Site'),
-            # Translators: This is a result that was actually achieved, versus one that was planned.
-            'achieved': _('Actual value'),
-            # Translators: field label that
+            # Translators: field label that identifies which of a set of a targets (e.g. monthly/annual) a result is being compared to
             'periodic_target': _('Measure against target'),
             'evidence_url': _('Link to file or folder'),
         }

--- a/templates/indicators/indicator_form_common_js.html
+++ b/templates/indicators/indicator_form_common_js.html
@@ -395,7 +395,6 @@
 
     // Button click handler for CREATE form (save and add another)
     $("#indicator_modal_content").on("click", "#id_save_and_add_another_indicator_btn", function(e){
-        console.log(initialLevelId())
         if (validateForm() === false) {
             showValidations("#modalmessages");
             return;
@@ -465,7 +464,7 @@
                         <a href="#" class="deletebtn btn btn-sm event-target-delete-button">
                             <i class="fas fa-times text-danger"></i>
                         </a>
-                        <input type="text" placeholder="{% trans 'Enter event name' %}" class="form-control input-text">
+                        <input type="text" placeholder="{% trans 'Enter event name' %}" class="form-control input-text target-label">
                                 <span style="margin:0px;" class="help-block"> </span>
                     </div>
 
@@ -954,7 +953,6 @@
                 errorFlag = true;
             }
         });
-
         if (errorFlag) {
             showTargetErrors(getPTMessage());
             return false;
@@ -974,6 +972,14 @@
                 if (val === null) {
                     allValid = false;
                 }
+            }
+        });
+        $("#periodic_targets_table .target-label").each(function(){
+            if ($(this).val()) {
+                $(this).removeClass('is-invalid');
+            } else {
+                $(this).addClass('is-invalid');
+                allValid = false;
             }
         });
 
@@ -1131,7 +1137,7 @@
         } else {
             $(this).addClass('is-invalid');
         }
-        if ($("#id_div_periodic_tables_placeholder input[type=text], input[type=number]").hasClass("has-error") ) {
+        if ($("#id_div_periodic_tables_placeholder input[type=text], input[type=number]").hasClass('is-invalid') ) {
             showTargetErrors(getPTMessage());
         }
     });

--- a/templates/indicators/indicator_form_modal.html
+++ b/templates/indicators/indicator_form_modal.html
@@ -54,6 +54,7 @@
             id="indicator_update_form"
             class="form-horizontal"
             method="post"
+            autocomplete="off"
             novalidate>
 
         <div class="indicator-setup tab-set--vertical" id="indicator_modal_body">

--- a/templates/indicators/indicatortargets.html
+++ b/templates/indicators/indicatortargets.html
@@ -50,7 +50,7 @@
                                        placeholder="{% trans 'Enter event name' %}"
                                        name="{{ pt.period }}"
                                        value="{{ pt.period }}"
-                                       class="form-control input-text"
+                                       class="form-control input-text target-label"
                                        {% if readonly %}disabled="disabled"{% endif %}>
                                 <span style="" class="help-block"> </span>
                             </div>

--- a/templates/indicators/result_form_modal.html
+++ b/templates/indicators/result_form_modal.html
@@ -118,6 +118,7 @@
         id="result_update_form"
         class=""
         method="post"
+        autocomplete="off"
         novalidate>
         {% csrf_token %}
 

--- a/templates/indicators/results/result_form_disaggregation_fields.html
+++ b/templates/indicators/results/result_form_disaggregation_fields.html
@@ -85,6 +85,9 @@
         $( this ).removeClass('is-invalid');
         if ($( this ).val() == '') {
             // user entered blank, do nothing
+        } else if ($( this ).val() == ',' || $( this ).val() == '.') {
+            $( this ).val('');
+            // user entered a comma or . and tabbed out, do nothing
         } else if ($( this ).numericVal() === null || $(this).numericVal() < 0) {
             $( this ).addClass('is-invalid');
         }
@@ -107,7 +110,7 @@
                 // disaggregation is empty (all blank)
                 $( this ).find('.sum-value-cell').html('');
             } else {
-                let sumValue = values.filter(val => val > 0).reduce((a, b) => a + b);
+                let sumValue = values.filter(val => val > 0).reduce((a, b) => a + b, 0);
                 $( this ).find('.sum-value-cell').displayVal(sumValue, percentageInput);
             }
         }


### PR DESCRIPTION
Set of minor bugfixes for numeric inputs localization and target validation, closes #2217 #2218  #2082  and #2210  (event target names cannot be blank, entering only a "," or "." should be cleared, disaggregated values of 0 are allowed, and targets can individually be 0 (but not sum to 0 for LoP)