### PR TITLE
a second expected key was not earlier provided, so accessing old data…

### DIFF
--- a/tola_management/programadmin.py
+++ b/tola_management/programadmin.py
@@ -91,7 +91,7 @@ def get_audit_log_workbook(ws, program):
                 output_string += f"\r\n{disagg_type}\r\n"
             else:
                 output_string += "\r\n"
-            disaggs[disagg_type].sort(key=lambda item: "" if item["custom_sort"] is None else item["custom_sort"])
+            disaggs[disagg_type].sort(key=lambda item: item.get('customsort', ''))
 
             for item in disaggs[disagg_type]:
                 output_string += f"{item['name']}: {item['value']}\r\n"


### PR DESCRIPTION
… without a fallback results in a crash

The 'customsort' key is now provided because labels are reorderable.  The data that was stored previous to goat tree does not include this customsort information.  By providing an information-less default we get unpredictably-ordered labels, but that's the current behavior so no loss of functionality, and no crash.