### PR TITLE
2376 disagg sorting

### DIFF
--- a/indicators/export_renderers.py
+++ b/indicators/export_renderers.py
@@ -316,7 +316,8 @@ class ExcelRendererBase:
         self.write_indicator_row(sheet, current_row, indicator_columns)
         current_row += 1
         label_merge_column = len(self.header_columns) - (1 if self.baseline_column else 0)
-        for disaggregation in indicator.get('disaggregations', []):
+        for disaggregation in sorted(indicator.get('disaggregations', []),
+                                     key=lambda disagg: ugettext(disagg['name'])):
             top_row = current_row
             for label in disaggregation['labels']:
                 # only include row if we are _not_ hiding empty categories or this category isn't empty:

--- a/indicators/views/views_indicators.py
+++ b/indicators/views/views_indicators.py
@@ -797,8 +797,12 @@ class ResultCreate(ResultFormMixin, CreateView):
             str(self.indicator.form_title_level),
             str(self.indicator.name)
         )
-        disaggregations = self.indicator.disaggregation.all().order_by('disaggregation_type')
-        context['disaggregation_forms'] = [get_disaggregated_result_formset(disagg)(request=self.request) for disagg in disaggregations]
+        context['disaggregation_forms'] = [
+            get_disaggregated_result_formset(disagg)(request=self.request)
+            for disagg in sorted(
+                self.indicator.disaggregation.all(),
+                key=lambda disagg: ugettext(disagg.disaggregation_type))
+            ]
         return context
 
     def get_form_kwargs(self):
@@ -856,7 +860,9 @@ class ResultUpdate(ResultFormMixin, UpdateView):
         )
         context['disaggregation_forms'] = [
             get_disaggregated_result_formset(disagg)(result=self.result, request=self.request)
-            for disagg in self.indicator.disaggregation.all().order_by('disaggregation_type')
+            for disagg in sorted(
+                self.indicator.disaggregation.all(),
+                key=lambda disagg: ugettext(disagg.disaggregation_type))
         ]
         return context
 


### PR DESCRIPTION
Sorting disaggregations per #2376 - should sort by _translated_ name in exports/web view/result form.  This makes those changes to result form and export (translating before sort).